### PR TITLE
release: 0.2.3-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented in this file. The format roug
 
 - _Nothing yet_
 
+## [0.2.3-beta] - 2025-10-03
+
+### Fixed
+- Pin `setuptools.packages` discovery to the integration module so editable installs succeed when blueprints are bundled.
+
+### Changed
+- Document the local workflow for validating both Python 3.12 and 3.13 matrix jobs before opening a pull request.
+
 ## [0.2.2-beta] - 2025-10-03
 
 ### Added

--- a/custom_components/webasto_next_modbus/manifest.json
+++ b/custom_components/webasto_next_modbus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "webasto_next_modbus",
   "name": "Webasto Next Modbus",
-  "version": "0.2.2-beta",
+  "version": "0.2.3-beta",
   "documentation": "https://github.com/tomwellnitz/Webasto-Next-Modbus",
   "issue_tracker": "https://github.com/tomwellnitz/Webasto-Next-Modbus/issues",
   "requirements": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "webasto-next-modbus"
-version = "0.2.2-beta"
+version = "0.2.3-beta"
 description = "Home Assistant integration for Webasto Next / Ampure Unite wallboxes via Modbus TCP"
 authors = [{ name = "Webasto Next Modbus maintainers" }]
 readme = "README.md"
@@ -27,6 +27,9 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "UP", "ASYNC", "C4", "TID"]
+
+[tool.setuptools]
+packages = ["custom_components.webasto_next_modbus"]
 
 [build-system]
 requires = ["setuptools>=68"]


### PR DESCRIPTION
## Summary
- lock setuptools package discovery to the integration module to unblock editable installs
- document the workflow notes for validating both CI Python versions
- bump version metadata and changelog for 0.2.3-beta

## Testing
- .venv/bin/python -m ruff check custom_components/webasto_next_modbus tests
- .venv/bin/pytest
- .venv/bin/python -m pip install -e '.[dev]'
