### PR TITLE
fix: redact REST credentials in diagnostics, guard life-bit busy-loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,14 @@
 - **Config flow**: `_abort_if_unique_id_configured(reload_on_update=False)` is now passed explicitly to opt out of the implicit reload-on-update path. Combined with the existing update listener this future-proofs us against the deprecation that turns into an error in Home Assistant 2026.12.
 - **Service resolver**: Looks up loaded entries via `hass.config_entries.async_loaded_entries(DOMAIN)` and reads each entry's `runtime_data`, removing the last direct dependency on `hass.data[DOMAIN]`.
 
+### Fixed
+
+- **Diagnostics**: The REST API username and password are now redacted from the config-entry diagnostics download (previously only `host` was redacted, so the password stored in entry options was exposed).
+- **Life-bit loop**: The keep-alive polling window is clamped to a sane minimum and a one-second floor was added between keep-alive cycles, so a `0`/garbage value in the failsafe-timeout register can no longer turn the loop into a tight read/write spin that hammers the wallbox and starves the data poll.
+
 ### Internal
 
+- Removed the unused, stale `INTEGRATION_VERSION` constant from `const.py` (the integration version lives in `manifest.json` / `pyproject.toml`).
 - Bumped README maintenance badge to 2026.
 - Documented in `AGENTS.md` that `pymodbus` / `aiohttp` constraints must stay synchronised between `pyproject.toml` and `custom_components/webasto_next_modbus/manifest.json`.
 

--- a/custom_components/webasto_next_modbus/const.py
+++ b/custom_components/webasto_next_modbus/const.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import Final, Literal
 
 DOMAIN: Final = "webasto_next_modbus"
-INTEGRATION_VERSION: Final = "1.1.5"
 DEFAULT_PORT: Final = 502
 DEFAULT_UNIT_ID: Final = 255
 DEFAULT_SCAN_INTERVAL: Final = 10  # seconds

--- a/custom_components/webasto_next_modbus/diagnostics.py
+++ b/custom_components/webasto_next_modbus/diagnostics.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
 from . import WebastoConfigEntry
+from .const import CONF_REST_PASSWORD, CONF_REST_USERNAME
 
-TO_REDACT = {"host"}
+TO_REDACT = {CONF_HOST, CONF_REST_PASSWORD, CONF_REST_USERNAME}
 
 
 def _iso_or_none(value):

--- a/custom_components/webasto_next_modbus/hub.py
+++ b/custom_components/webasto_next_modbus/hub.py
@@ -30,6 +30,11 @@ _LOGGER = logging.getLogger(__name__)
 
 MAX_REGISTERS_PER_REQUEST: Final = 110
 
+# Lower bound for the life-bit polling window. Guards against a 0/garbage
+# value in the failsafe-timeout register turning the loop into a tight
+# read/write spin that would hammer the wallbox and starve the data poll.
+LIFE_BIT_MIN_INTERVAL: Final = 10
+
 
 class WebastoModbusError(Exception):
     """Raised when a Modbus communication error occurs."""
@@ -181,7 +186,7 @@ class ModbusBridge:
                 try:
                     val = await self.async_read_register(timeout_reg)
                     if isinstance(val, (int, float)):
-                        poll_timeout = int(val)
+                        poll_timeout = max(int(val), LIFE_BIT_MIN_INTERVAL)
                 except Exception:
                     # Ignore read errors for timeout, use default/last known or just proceed
                     pass
@@ -199,6 +204,10 @@ class ModbusBridge:
                         )
                         break
                     await asyncio.sleep(1)
+
+                # Floor between keep-alive cycles so a fast-clearing life bit
+                # cannot turn this into a tight write loop.
+                await asyncio.sleep(1)
 
             except asyncio.CancelledError:
                 raise


### PR DESCRIPTION
## Summary

Follow-up to #42 / #43 — three low-risk fixes from a code audit of the integration. No behaviour change for normal operation; folds into the unreleased `1.1.7`.

### 1. Diagnostics leaked the REST password (security)

`diagnostics.py` only redacted `host`, but the REST API username **and password** are stored in `entry.options` (see `config_flow.py`), so they appeared in clear text in the config-entry diagnostics download — which users routinely attach to bug reports.

```diff
-TO_REDACT = {"host"}
+TO_REDACT = {CONF_HOST, CONF_REST_PASSWORD, CONF_REST_USERNAME}
```

### 2. Life-bit loop could become a tight read/write spin

`ModbusBridge._life_bit_loop` reads `failsafe_timeout_s` into `poll_timeout`. If that register reads `0` (failsafe disabled) or a garbage value, the inner `while time.time() - start < poll_timeout` loop never runs, so the outer loop fires `read` + `write` back-to-back with no pause — hammering the wallbox and starving the data poll (both share `ModbusBridge._lock`).

Fix: clamp `poll_timeout` to a `LIFE_BIT_MIN_INTERVAL` (10 s) floor, and add a 1 s sleep between keep-alive cycles so a fast-clearing life bit can't spin the loop either.

### 3. Dropped stale `INTEGRATION_VERSION` constant

`const.py` defined `INTEGRATION_VERSION = "1.1.5"` — unused anywhere and out of sync with `manifest.json` / `pyproject.toml` (`1.1.7`). Removed.

## Test plan

- [ ] CI green on Python 3.14.2 (ruff, codespell, yamllint, bandit, deptry, vulture, mypy, pytest)
- [ ] HACS validation passes
- [ ] Hassfest validation passes
- [ ] Download config-entry diagnostics for an entry with REST enabled → confirm `rest_password` / `rest_username` show `**REDACTED**`

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_