### PR TITLE
chore: audit follow-up — drop aiohttp from manifest, public accessors, dead code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,10 +99,8 @@ This script executes:
 
 ### 5. Dependency Pinning
 
-- Runtime dependencies (`pymodbus`, `aiohttp`, …) are declared in **two** places that must stay in sync:
-  - `pyproject.toml` under `[project].dependencies`
-  - `custom_components/webasto_next_modbus/manifest.json` under `requirements`
-- HACS / hassfest validation will fail if these drift apart. Update both in the same commit.
+- `manifest.json` `requirements` lists **only** packages that Home Assistant core does not already provide — currently just `pymodbus`. `aiohttp` is part of HA core, so it must **not** be listed in the manifest (a `>=` requirement there can interfere with pip resolving HA core's own pin). It still belongs in `pyproject.toml` `[project].dependencies` because the test/dev environment imports it directly (`rest_client.py`).
+- Where a package appears in **both** `pyproject.toml` and `manifest.json` (i.e. `pymodbus`), the version specifiers must stay in sync — HACS / hassfest validation flags drift. Update both in the same commit.
 - `pymodbus` is pinned to `>=3.11.2,<3.12` to match the version Home Assistant core's built-in `modbus` integration pins. Do **not** loosen this bound without first checking that HA core's pin has moved — pymodbus 3.12+ removed `ModbusDeviceContext.store`/`decode` and added a `SimDevice` validator that breaks our virtual wallbox.
 
 ## 🧪 Testing Strategy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- `manifest.json` no longer lists `aiohttp` as a requirement: it is part of Home Assistant core, and a `>=` requirement in the manifest can interfere with pip resolving the core pin. It stays in `pyproject.toml` for the test environment.
+
+### Internal
+
+- Removed a redundant `available` override on the Modbus register entity base class (it just returned the coordinator-entity default).
+- Replaced a few private-attribute accesses with public accessors: external code now uses `WebastoDataCoordinator.rest_client` and `ModbusBridge.host` / `ModbusBridge.unit_id`.
+
 ## [1.1.7] - 2026-05-11
 
 ### Changed

--- a/custom_components/webasto_next_modbus/__init__.py
+++ b/custom_components/webasto_next_modbus/__init__.py
@@ -470,7 +470,7 @@ async def _async_service_set_led_brightness(call: ServiceCall) -> None:
         raise HomeAssistantError("REST API is not enabled for this wallbox")
 
     brightness = int(call.data["brightness"])
-    rest_client = runtime.coordinator._rest_client
+    rest_client = runtime.coordinator.rest_client
     if rest_client is None:
         raise HomeAssistantError("REST client not available")
 
@@ -490,7 +490,7 @@ async def _async_service_set_free_charging(call: ServiceCall) -> None:
         raise HomeAssistantError("REST API is not enabled for this wallbox")
 
     enabled = bool(call.data["enabled"])
-    rest_client = runtime.coordinator._rest_client
+    rest_client = runtime.coordinator.rest_client
     if rest_client is None:
         raise HomeAssistantError("REST client not available")
 
@@ -509,7 +509,7 @@ async def _async_service_restart_wallbox(call: ServiceCall) -> None:
     if not runtime.coordinator.rest_enabled:
         raise HomeAssistantError("REST API is not enabled for this wallbox")
 
-    rest_client = runtime.coordinator._rest_client
+    rest_client = runtime.coordinator.rest_client
     if rest_client is None:
         raise HomeAssistantError("REST client not available")
 

--- a/custom_components/webasto_next_modbus/button.py
+++ b/custom_components/webasto_next_modbus/button.py
@@ -102,7 +102,7 @@ class WebastoRestartButton(WebastoRestEntity, ButtonEntity):  # type: ignore[mis
         device_name: str,
     ) -> None:
         super().__init__(
-            coordinator, host, unit_id, "restart_system", device_name, coordinator._rest_client
+            coordinator, host, unit_id, "restart_system", device_name, coordinator.rest_client
         )
 
     async def async_press(self) -> None:

--- a/custom_components/webasto_next_modbus/config_flow.py
+++ b/custom_components/webasto_next_modbus/config_flow.py
@@ -186,7 +186,7 @@ class WebastoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 continue
             bridge = runtime.bridge
             # Check if this bridge matches the host/unit_id we're testing
-            if bridge._host == host and bridge._unit_id == unit_id:
+            if bridge.host == host and bridge.unit_id == unit_id:
                 return bridge
         return None
 

--- a/custom_components/webasto_next_modbus/entity.py
+++ b/custom_components/webasto_next_modbus/entity.py
@@ -118,12 +118,6 @@ class WebastoRegisterEntity(CoordinatorEntity[WebastoDataCoordinator]):
 
         return self.coordinator.data.get(self._register.key)
 
-    @property
-    def available(self) -> bool | None:  # type: ignore[override]
-        """Return availability aligned with Entity expectations."""
-
-        return super().available
-
 
 class WebastoRestEntity(CoordinatorEntity[WebastoDataCoordinator]):
     """Base entity for REST API data."""

--- a/custom_components/webasto_next_modbus/hub.py
+++ b/custom_components/webasto_next_modbus/hub.py
@@ -545,6 +545,18 @@ class ModbusBridge:
             )
 
     @property
+    def host(self) -> str:
+        """Return the configured Modbus host."""
+
+        return self._host
+
+    @property
+    def unit_id(self) -> int:
+        """Return the configured Modbus unit / device id."""
+
+        return self._unit_id
+
+    @property
     def endpoint(self) -> str:
         """Return the Modbus endpoint for logging/diagnostics."""
 

--- a/custom_components/webasto_next_modbus/manifest.json
+++ b/custom_components/webasto_next_modbus/manifest.json
@@ -16,8 +16,7 @@
   ],
   "quality_scale": "silver",
   "requirements": [
-    "pymodbus>=3.11.2,<3.12",
-    "aiohttp>=3.13.5"
+    "pymodbus>=3.11.2,<3.12"
   ],
   "version": "1.1.7"
 }

--- a/custom_components/webasto_next_modbus/number.py
+++ b/custom_components/webasto_next_modbus/number.py
@@ -219,7 +219,7 @@ class WebastoLedBrightness(WebastoRestEntity, NumberEntity):  # type: ignore[mis
         device_name: str,
     ) -> None:
         super().__init__(
-            coordinator, host, unit_id, "led_brightness", device_name, coordinator._rest_client
+            coordinator, host, unit_id, "led_brightness", device_name, coordinator.rest_client
         )
         self._pending_value: int | None = None
 

--- a/custom_components/webasto_next_modbus/switch.py
+++ b/custom_components/webasto_next_modbus/switch.py
@@ -58,7 +58,7 @@ class WebastoFreeChargingSwitch(WebastoRestEntity, SwitchEntity):  # type: ignor
     ) -> None:
         """Initialize the Free Charging switch."""
         super().__init__(
-            coordinator, host, unit_id, "free_charging", device_name, coordinator._rest_client
+            coordinator, host, unit_id, "free_charging", device_name, coordinator.rest_client
         )
         self._pending_state: bool | None = None
         self._attr_is_on: bool | None = None


### PR DESCRIPTION
Second round of small audit follow-ups (after #44). No behaviour change for users; all internal hygiene plus one packaging cleanup.

## Changes

* **`manifest.json`: drop the `aiohttp` requirement.** `aiohttp` is part of Home Assistant core, so listing it (with a `>=` bound) in the integration manifest can interfere with pip resolving the core pin. It stays in `pyproject.toml` `[project].dependencies` because the test/dev environment imports it directly (`rest_client.py`). Hassfest/HACS validation stays green either way.
* **Use public accessors instead of private attributes.** External code now uses `WebastoDataCoordinator.rest_client` (the existing property) instead of `coordinator._rest_client` — in the REST service handlers and the LED-brightness / free-charging / restart entity constructors — and `config_flow` uses new `ModbusBridge.host` / `ModbusBridge.unit_id` properties instead of poking `_host` / `_unit_id`.
* **Remove a dead override.** `WebastoRegisterEntity.available` only returned `super().available`; deleted.
* **AGENTS.md**: clarify that `manifest.json` lists only packages HA core doesn't provide (currently just `pymodbus`), and that `aiohttp` belongs only in `pyproject.toml`.

## Not done (and why)

The audit also flagged reverting the PEP-758 `except A, B:` form to `except (A, B):`. Skipped: `ruff format` rewrites the parenthesised form back to the bare form for a `requires-python >= 3.14.2` project (CI runs a `ruff format` check), so a revert would need pinning ruff's `target-version` below the actual `requires-python` — the wrong direction. The bare form is correct here; the Copilot false-positives it triggers are a Copilot issue, not ours.

## Test plan

- [ ] CI green on Python 3.14.2 (ruff, codespell, yamllint, bandit, deptry, vulture, mypy, pytest)
- [ ] HACS validation passes
- [ ] Hassfest validation passes (without `aiohttp` in the manifest)

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_