### PR TITLE
ci: mark pre-release tags as GitHub pre-releases; fold Unreleased into 1.1.7 changelog

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,8 @@ jobs:
           fi
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: webasto_next_modbus.zip
           body_path: RELEASE_NOTES.md
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,5 @@
 # Changelog
 
-## [Unreleased]
-
-### Changed
-
-- `manifest.json` no longer lists `aiohttp` as a requirement: it is part of Home Assistant core, and a `>=` requirement in the manifest can interfere with pip resolving the core pin. It stays in `pyproject.toml` for the test environment.
-
-### Internal
-
-- Removed a redundant `available` override on the Modbus register entity base class (it just returned the coordinator-entity default).
-- Replaced a few private-attribute accesses with public accessors: external code now uses `WebastoDataCoordinator.rest_client` and `ModbusBridge.host` / `ModbusBridge.unit_id`.
-
 ## [1.1.7] - 2026-05-11
 
 ### Changed
@@ -19,6 +8,7 @@
 - **Options flow**: No longer assigns `self.config_entry` explicitly; the base class injects it automatically (Home Assistant 2024.12+). Removes a deprecation warning that would otherwise become an error.
 - **Config flow**: `_abort_if_unique_id_configured(reload_on_update=False)` is now passed explicitly to opt out of the implicit reload-on-update path. Combined with the existing update listener this future-proofs us against the deprecation that turns into an error in Home Assistant 2026.12.
 - **Service resolver**: Looks up loaded entries via `hass.config_entries.async_loaded_entries(DOMAIN)` and reads each entry's `runtime_data`, removing the last direct dependency on `hass.data[DOMAIN]`.
+- `manifest.json` no longer lists `aiohttp` as a requirement: it is part of Home Assistant core, and a `>=` requirement in the manifest can interfere with pip resolving the core pin. It stays in `pyproject.toml` for the test environment.
 
 ### Fixed
 
@@ -28,8 +18,11 @@
 ### Internal
 
 - Removed the unused, stale `INTEGRATION_VERSION` constant from `const.py` (the integration version lives in `manifest.json` / `pyproject.toml`).
+- Removed a redundant `available` override on the Modbus register entity base class (it just returned the coordinator-entity default).
+- Replaced a few private-attribute accesses with public accessors: external code now uses `WebastoDataCoordinator.rest_client` and `ModbusBridge.host` / `ModbusBridge.unit_id`.
 - Bumped README maintenance badge to 2026.
-- Documented in `AGENTS.md` that `pymodbus` / `aiohttp` constraints must stay synchronised between `pyproject.toml` and `custom_components/webasto_next_modbus/manifest.json`.
+- Documented the dependency-pinning conventions in `AGENTS.md` (`manifest.json` lists only packages HA core does not provide; `pymodbus` stays pinned to `<3.12`).
+- Release workflow: pre-release tags (`v*-beta.*`, `v*-rc.*`, …) are now published as GitHub pre-releases so HACS only offers them under "Show beta versions".
 
 ## [1.1.6] - 2026-05-11
 


### PR DESCRIPTION
## Why

`v1.1.7-beta.1` got published as a **full** GitHub release (not a pre-release), because `softprops/action-gh-release` defaults `prerelease` to `false` and doesn't infer it from the tag name. HACS would then offer that beta to everyone as the latest stable. (Workaround for the already-published `v1.1.7-beta.1`: edit the release on GitHub and tick "Set as a pre-release".)

Also, `1.1.7` hasn't shipped yet, so the `[Unreleased]` changelog entries (from #46) were sitting in a section the release workflow's note extraction (`sed -n "/## \[$VERSION\]/,/## \[/p"`) wouldn't pick up when tagging `v1.1.7`.

## Changes

* **`.github/workflows/release.yaml`**: bump `softprops/action-gh-release` `v1` → `v2` and add `prerelease: ${{ contains(github.ref_name, '-') }}` — so `v*-beta.*` / `v*-rc.*` / `v*-alpha.*` tags publish as GitHub pre-releases (and clean `v1.2.3` tags as full releases).
* **`CHANGELOG.md`**: fold the `[Unreleased]` section into `[1.1.7] - 2026-05-11` (it's not released yet), and add a line about the pre-release-tag change. No more dangling `[Unreleased]` on `main`.

Not done here: `actions/checkout@v4` → `@v5` (Node 20 deprecation) — that touches `ci.yaml` too and is a separate cleanup.

## Test plan

- [ ] CI green (ruff / yamllint pick up the workflow change)
- [ ] Next stable `v1.1.7` tag → release notes come from the `[1.1.7]` section, `prerelease: false`
- [ ] A `v1.2.0-beta.1` tag → published with `prerelease: true`

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_