### PR TITLE
ci: bump GitHub Actions to latest majors; tune dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,29 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    # Only direct dependencies declared in pyproject.toml; there is no lock
+    # file, so transitive bumps would just be noise.
     allow:
-      - dependency-type: "all"
+      - dependency-type: "direct"
+    ignore:
+      # pymodbus is pinned to match Home Assistant core's `modbus` integration
+      # (pymodbus==3.11.2 as of HA 2026.5); see AGENTS.md. Only patch bumps
+      # within the 3.11.x line are acceptable until HA core moves.
+      - dependency-name: "pymodbus"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: HACS validation
         uses: hacs/action@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: HACS validation
         uses: hacs/action@main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,17 +24,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,17 +24,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -58,7 +58,7 @@ jobs:
           fi
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: webasto_next_modbus.zip
           body_path: RELEASE_NOTES.md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -58,7 +58,7 @@ jobs:
           fi
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: webasto_next_modbus.zip
           body_path: RELEASE_NOTES.md


### PR DESCRIPTION
## Why

The build job was warning about `actions/checkout@v4` running on Node 20 (deprecated). Bringing all GitHub Actions current, **pinned to commit SHAs** (GitHub's hardening guidance — a force-pushed/hijacked tag can't change what runs), and tightening the Dependabot config so it stops opening stale/noise PRs.

**Verified:** Home Assistant core's built-in `modbus` integration still pins `pymodbus==3.11.2` (checked `home-assistant/core@dev` and the `2026.5.1` tag), so our `pymodbus>=3.11.2,<3.12` pin stays — Dependabot is now told to ignore pymodbus major/minor bumps (patch bumps within 3.11.x still come through).

## Changes

### `.github/workflows/*` — pin to SHA, version comment for Dependabot
* `actions/checkout` → `de0fac2…` (`v6.0.2`) — ci.yaml, release.yaml, codeql.yml
* `astral-sh/setup-uv` → `0880764…` (`v8.1.0`) — ci.yaml, release.yaml
* `softprops/action-gh-release` → `b430933…` (`v3.0.0`, Node 24 runtime) — release.yaml; supersedes Dependabot #40
* `github/codeql-action/{init,autobuild,analyze}` → `68bde55…` (`v4`) — codeql.yml
* `hacs/action@main` / `home-assistant/actions/hassfest@master` left on branch refs — those actions don't cut tagged releases and the HA docs prescribe running them from the branch tip. Dependabot still bumps the SHA-pinned ones (and updates the `# vX.Y.Z` comment).

### `.github/dependabot.yml`
* `pip`: `allow: dependency-type: "direct"` (was `"all"` — there's no lock file, so transitive bumps were just noise; that's where the stale `pygments` PR came from)
* `pip`: `ignore` pymodbus major + minor bumps (pinned to match HA core; see AGENTS.md)
* group `pip` and `github-actions` updates into one weekly PR each
* `open-pull-requests-limit: 5` on both ecosystems

## Follow-ups (separate)
* Close Dependabot #48 (`pymodbus` `<3.12` → `<3.14`) — would break the virtual wallbox / conflict with HA core; the new `ignore` rule prevents it from being re-opened.
* Close Dependabot #40 (`action-gh-release` v2→v3) — done here.

## Test plan
- [ ] CI green with the SHA-pinned action versions (ruff / codespell / yamllint / bandit / deptry / vulture / mypy / pytest, plus HACS + hassfest jobs and CodeQL)
- [ ] Next release tag still publishes correctly via the SHA-pinned `action-gh-release`

---
_Generated by Claude Code_