### PR TITLE
feat: raise a repair issue when the REST API credentials are rejected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Config flow**: `_abort_if_unique_id_configured(reload_on_update=False)` is now passed explicitly to opt out of the implicit reload-on-update path. Combined with the existing update listener this future-proofs us against the deprecation that turns into an error in Home Assistant 2026.12.
 - **Service resolver**: Looks up loaded entries via `hass.config_entries.async_loaded_entries(DOMAIN)` and reads each entry's `runtime_data`, removing the last direct dependency on `hass.data[DOMAIN]`.
 - `manifest.json` no longer lists `aiohttp` as a requirement: it is part of Home Assistant core, and a `>=` requirement in the manifest can interfere with pip resolving the core pin. It stays in `pyproject.toml` for the test environment.
+- When the wallbox rejects the configured REST API credentials (HTTP 401), the integration now raises a **repair issue** ("REST API authentication failed") instead of only logging a warning, so it's visible and you know to update the password. The Modbus side keeps working regardless. A non-401 REST login failure (e.g. the wallbox web server still booting) is treated as a transient connection error and retried, not flagged as a credentials problem.
 
 ### Fixed
 

--- a/custom_components/webasto_next_modbus/coordinator.py
+++ b/custom_components/webasto_next_modbus/coordinator.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.components import persistent_notification
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -36,6 +37,9 @@ if TYPE_CHECKING:
     from .rest_client import RestClient, RestData
 
 _LOGGER = logging.getLogger(__name__)
+
+# Repair-issue key for "REST credentials rejected".
+ISSUE_REST_AUTH = "rest_auth_failed"
 
 
 class WebastoDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -96,7 +100,7 @@ class WebastoDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return
 
         # Import here to avoid circular imports
-        from .rest_client import RestClient
+        from .rest_client import AuthenticationError, RestClient
 
         host = self._bridge.endpoint.split(":")[0]
         self._rest_client = RestClient(host, username, password)
@@ -105,6 +109,16 @@ class WebastoDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             await self._rest_client.connect()
             _LOGGER.info("REST API client connected successfully")
             self._rest_setup_retry_at = None
+            self._clear_rest_auth_issue()
+        except AuthenticationError as err:
+            _LOGGER.warning("REST API authentication failed: %s", err)
+            with contextlib.suppress(Exception):
+                await self._rest_client.disconnect()
+            self._rest_client = None
+            # Wrong credentials won't fix themselves by retrying — surface a
+            # repair issue so the user updates them in the options.
+            self._rest_setup_retry_at = None
+            self._raise_rest_auth_issue()
         except Exception as err:  # noqa: BLE001
             _LOGGER.warning("Failed to connect REST API client: %s", err)
             with contextlib.suppress(Exception):
@@ -113,8 +127,25 @@ class WebastoDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # The wallbox may just be booting; retry later from the data poll.
             self._rest_setup_retry_at = datetime.now(UTC) + self._rest_setup_retry_interval
 
+    def _rest_auth_issue_id(self) -> str:
+        return f"{ISSUE_REST_AUTH}_{self.entry_id}"
+
+    def _raise_rest_auth_issue(self) -> None:
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            self._rest_auth_issue_id(),
+            is_fixable=False,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key=ISSUE_REST_AUTH,
+        )
+
+    def _clear_rest_auth_issue(self) -> None:
+        ir.async_delete_issue(self.hass, DOMAIN, self._rest_auth_issue_id())
+
     async def async_shutdown_rest_client(self) -> None:
-        """Disconnect REST client."""
+        """Disconnect the REST client and clear any REST repair issue."""
+        self._clear_rest_auth_issue()
         if self._rest_client is not None:
             await self._rest_client.disconnect()
             self._rest_client = None

--- a/custom_components/webasto_next_modbus/rest_client.py
+++ b/custom_components/webasto_next_modbus/rest_client.py
@@ -326,8 +326,11 @@ class RestClient:
                     msg = "Invalid username or password"
                     raise AuthenticationError(msg)
                 if resp.status != 200:
+                    # Not a credentials problem (e.g. the wallbox web server is
+                    # still coming up) — treat it as a connection error so the
+                    # caller retries instead of flagging the credentials.
                     msg = f"Login failed with status {resp.status}"
-                    raise AuthenticationError(msg)
+                    raise ConnectionError(msg)
 
                 data = await resp.json()
                 self._token = data.get("access_token")

--- a/custom_components/webasto_next_modbus/translations/de.json
+++ b/custom_components/webasto_next_modbus/translations/de.json
@@ -246,5 +246,11 @@
     "abort": {
       "missing_dependency": "Das benötigte Paket 'voluptuous' fehlt in dieser Home Assistant Umgebung."
     }
+  },
+  "issues": {
+    "rest_auth_failed": {
+      "title": "Webasto Next: REST-API-Anmeldung fehlgeschlagen",
+      "description": "Der REST-API-Benutzername oder das Passwort werden von der Wallbox nicht mehr akzeptiert. Bitte in den Integrations-Optionen aktualisieren (Einstellungen → Geräte & Dienste → Webasto Next → Konfigurieren). Die Modbus-Seite läuft in der Zwischenzeit weiter."
+    }
   }
 }

--- a/custom_components/webasto_next_modbus/translations/en.json
+++ b/custom_components/webasto_next_modbus/translations/en.json
@@ -245,5 +245,11 @@
         "name": "Free Charging"
       }
     }
+  },
+  "issues": {
+    "rest_auth_failed": {
+      "title": "Webasto Next: REST API authentication failed",
+      "description": "The REST API username or password is no longer accepted by the wallbox. Update them in the integration options (Settings → Devices & Services → Webasto Next → Configure). The Modbus side keeps working in the meantime."
+    }
   }
 }


### PR DESCRIPTION
## Why

Today, if the wallbox rejects the configured REST API credentials, the integration just logs a warning and silently disables REST until the next reload — easy to miss. We discussed a reauth flow; since REST is *optional* (Modbus works without it), a full reauth flow that marks the whole device as "needs attention" felt heavy. A **repair issue** is the proportionate response: prominent (Settings → Repairs), points the user at the fix, and doesn't disrupt Modbus.

## What

* On `connect()` → HTTP 401 (`AuthenticationError`): create an ERROR repair issue (`rest_auth_failed`, per config entry) with a translated title/description telling the user to update the password in the options. Don't keep retrying (wrong credentials won't fix themselves). REST stays disabled, Modbus unaffected.
* The issue is cleared on a subsequent successful connect, and on unload.
* `RestClient._login()`: a non-401 non-200 (e.g. the wallbox web server still booting) is now a `ConnectionError` rather than an `AuthenticationError`, so the coordinator treats it as a transient outage and retries it (via the existing ~5-min retry path) instead of flagging the credentials.
* Translations for the issue (en + de); CHANGELOG entry.

Deliberately *not* a full HA reauth flow / fixable repair flow — that could be a later enhancement if wanted.

## Test plan
- [ ] CI green
- [ ] Set a wrong REST password → after the integration retries, a repair issue appears under Settings → Repairs; fix the password in the options → issue clears on next setup
- [ ] Modbus entities keep working while the REST repair issue is active
- [ ] REST connect failing because the wallbox is still booting → no repair issue, retried as before

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_