### PR TITLE
test: cover the new boot-resilience / REST / connectivity code paths

### DIFF
--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -244,6 +244,7 @@ async def test_coordinator_rest_auth_failure_raises_repair_issue() -> None:
     """A 401 on the REST login surfaces a repair issue and disables REST (no retry)."""
 
     bridge = AsyncMock(spec=ModbusBridge)
+    bridge.endpoint = "192.0.2.1:502 (device_id 255)"
     entry = MockConfigEntry(
         domain="webasto_next_modbus",
         entry_id="1234",
@@ -256,10 +257,12 @@ async def test_coordinator_rest_auth_failure_raises_repair_issue() -> None:
         patch("custom_components.webasto_next_modbus.rest_client.RestClient") as mock_rc,
     ):
         mock_rc.return_value.connect = AsyncMock(side_effect=AuthenticationError("bad creds"))
+        mock_rc.return_value.disconnect = AsyncMock()
         await coordinator.async_setup_rest_client()
 
     assert coordinator._rest_client is None
     assert coordinator._rest_setup_retry_at is None
+    mock_rc.return_value.disconnect.assert_awaited_once()
     mock_ir.async_create_issue.assert_called_once()
 
 
@@ -267,6 +270,7 @@ async def test_coordinator_clears_rest_auth_issue_on_success() -> None:
     """A successful REST connect clears the auth repair issue."""
 
     bridge = AsyncMock(spec=ModbusBridge)
+    bridge.endpoint = "192.0.2.1:502 (device_id 255)"
     entry = MockConfigEntry(
         domain="webasto_next_modbus",
         entry_id="1234",
@@ -279,6 +283,7 @@ async def test_coordinator_clears_rest_auth_issue_on_success() -> None:
         patch("custom_components.webasto_next_modbus.rest_client.RestClient") as mock_rc,
     ):
         mock_rc.return_value.connect = AsyncMock()
+        mock_rc.return_value.disconnect = AsyncMock()
         await coordinator.async_setup_rest_client()
 
     assert coordinator._rest_client is mock_rc.return_value

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.webasto_next_modbus.const import CONF_REST_ENABLED, CONF_REST_PASSWORD
 from custom_components.webasto_next_modbus.coordinator import WebastoDataCoordinator
 from custom_components.webasto_next_modbus.device_trigger import (
     TRIGGER_CHARGING_STARTED,
@@ -18,6 +19,7 @@ from custom_components.webasto_next_modbus.device_trigger import (
     TRIGGER_CONNECTION_RESTORED,
 )
 from custom_components.webasto_next_modbus.hub import ModbusBridge, WebastoModbusError
+from custom_components.webasto_next_modbus.rest_client import AuthenticationError
 
 pytestmark = pytest.mark.asyncio
 
@@ -198,3 +200,86 @@ async def test_coordinator_emits_connection_triggers() -> None:
     )
     assert restored_call.args[1] == "192.0.2.1-255"
     assert "timestamp" in restored_call.args[3]
+
+
+async def test_coordinator_retries_rest_setup_when_due() -> None:
+    """A previously failed REST setup is retried from the data poll once the interval passes."""
+
+    bridge = AsyncMock(spec=ModbusBridge)
+    bridge.async_read_data = AsyncMock(return_value={})
+    entry = MockConfigEntry(domain="webasto_next_modbus", entry_id="1234")
+
+    coordinator = _build_coordinator(bridge, entry)
+    coordinator.async_setup_rest_client = AsyncMock()
+    coordinator._rest_setup_retry_at = datetime.now(UTC) - timedelta(seconds=1)
+
+    with patch(
+        "custom_components.webasto_next_modbus.coordinator.persistent_notification.async_dismiss"
+    ):
+        await coordinator._async_update_data()
+
+    coordinator.async_setup_rest_client.assert_awaited_once()
+
+
+async def test_coordinator_does_not_retry_rest_setup_before_due() -> None:
+    """The REST setup retry is throttled by `_rest_setup_retry_at`."""
+
+    bridge = AsyncMock(spec=ModbusBridge)
+    bridge.async_read_data = AsyncMock(return_value={})
+    entry = MockConfigEntry(domain="webasto_next_modbus", entry_id="1234")
+
+    coordinator = _build_coordinator(bridge, entry)
+    coordinator.async_setup_rest_client = AsyncMock()
+    coordinator._rest_setup_retry_at = datetime.now(UTC) + timedelta(minutes=10)
+
+    with patch(
+        "custom_components.webasto_next_modbus.coordinator.persistent_notification.async_dismiss"
+    ):
+        await coordinator._async_update_data()
+
+    coordinator.async_setup_rest_client.assert_not_awaited()
+
+
+async def test_coordinator_rest_auth_failure_raises_repair_issue() -> None:
+    """A 401 on the REST login surfaces a repair issue and disables REST (no retry)."""
+
+    bridge = AsyncMock(spec=ModbusBridge)
+    entry = MockConfigEntry(
+        domain="webasto_next_modbus",
+        entry_id="1234",
+        options={CONF_REST_ENABLED: True, CONF_REST_PASSWORD: "secret"},
+    )
+    coordinator = _build_coordinator(bridge, entry)
+
+    with (
+        patch("custom_components.webasto_next_modbus.coordinator.ir") as mock_ir,
+        patch("custom_components.webasto_next_modbus.rest_client.RestClient") as mock_rc,
+    ):
+        mock_rc.return_value.connect = AsyncMock(side_effect=AuthenticationError("bad creds"))
+        await coordinator.async_setup_rest_client()
+
+    assert coordinator._rest_client is None
+    assert coordinator._rest_setup_retry_at is None
+    mock_ir.async_create_issue.assert_called_once()
+
+
+async def test_coordinator_clears_rest_auth_issue_on_success() -> None:
+    """A successful REST connect clears the auth repair issue."""
+
+    bridge = AsyncMock(spec=ModbusBridge)
+    entry = MockConfigEntry(
+        domain="webasto_next_modbus",
+        entry_id="1234",
+        options={CONF_REST_ENABLED: True, CONF_REST_PASSWORD: "secret"},
+    )
+    coordinator = _build_coordinator(bridge, entry)
+
+    with (
+        patch("custom_components.webasto_next_modbus.coordinator.ir") as mock_ir,
+        patch("custom_components.webasto_next_modbus.rest_client.RestClient") as mock_rc,
+    ):
+        mock_rc.return_value.connect = AsyncMock()
+        await coordinator.async_setup_rest_client()
+
+    assert coordinator._rest_client is mock_rc.return_value
+    mock_ir.async_delete_issue.assert_called_once()

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -388,3 +388,48 @@ async def test_write_only_number_restores_last_value(coordinator_fixture) -> Non
     number.async_write_ha_state.assert_called()
     assert number.native_value == 18
     assert number._last_written_value == 18
+
+
+async def test_write_only_number_seeds_from_wallbox(coordinator_fixture) -> None:
+    """A write-only number reads its current value from the wallbox on add."""
+
+    coordinator, bridge = coordinator_fixture
+    register = get_register("set_current_a")
+    bridge.async_read_register = AsyncMock(return_value=16)
+
+    number = WebastoNumber(coordinator, bridge, "192.0.2.30", 9, register, DEVICE_NAME, 32)
+    number.hass = MagicMock()
+    number.async_write_ha_state = MagicMock()
+    number.async_get_last_number_data = AsyncMock(return_value=MagicMock(native_value=24))
+
+    with patch(
+        "custom_components.webasto_next_modbus.number.async_dispatcher_connect",
+        return_value=lambda: None,
+    ):
+        await number.async_added_to_hass()
+
+    assert number.native_value == 16
+    assert number._last_written_value == 16
+    # The restore / re-apply fallback path was not used.
+    bridge.async_write_register.assert_not_awaited()
+    number.async_get_last_number_data.assert_not_awaited()
+
+
+async def test_connectivity_binary_sensor(coordinator_fixture) -> None:
+    """The connectivity sensor stays available and tracks last_update_success."""
+
+    from custom_components.webasto_next_modbus.binary_sensor import WebastoConnectivitySensor
+
+    coordinator, _bridge = coordinator_fixture
+    coordinator.last_update_success = True
+
+    sensor = WebastoConnectivitySensor(coordinator, "192.0.2.40", 3, DEVICE_NAME)
+
+    assert sensor.unique_id == "192.0.2.40-3-connected"
+    assert sensor.translation_key == "connected"
+    assert sensor.available is True
+    assert sensor.is_on is True
+
+    coordinator.last_update_success = False
+    assert sensor.available is True
+    assert sensor.is_on is False

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,6 +1,34 @@
-"""Tests for Modbus bridge decoding helpers."""
+"""Tests for Modbus bridge helpers."""
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 
-# Test entfernt, da RegisterDefinition für serial_number nicht mehr existiert
+from custom_components.webasto_next_modbus.hub import (
+    WebastoModbusDeviceError,
+    WebastoModbusError,
+    _describe_modbus_response,
+)
+
+
+def test_device_error_is_subclass_of_modbus_error() -> None:
+    """Device exceptions must still be caught by handlers expecting WebastoModbusError."""
+
+    assert issubclass(WebastoModbusDeviceError, WebastoModbusError)
+
+
+def test_describe_modbus_response_with_known_code() -> None:
+    text = _describe_modbus_response(SimpleNamespace(exception_code=2))
+    assert "exception code 2" in text
+    assert "Illegal Data Address" in text
+
+
+def test_describe_modbus_response_with_unknown_code() -> None:
+    text = _describe_modbus_response(SimpleNamespace(exception_code=99))
+    assert "exception code 99" in text
+    assert "unknown" in text
+
+
+def test_describe_modbus_response_falls_back_to_str() -> None:
+    # No exception_code attribute -> uses str() of the response.
+    assert "boom" in _describe_modbus_response(SimpleNamespace(detail="boom"))


### PR DESCRIPTION
## Why

The recent PRs (#50/#51/#52, and the Unite model in #45) added a fair bit of new code that Copilot rightly noted had no direct test coverage. This adds focused unit tests for it.

## What

* **`tests/test_hub.py`** — `WebastoModbusDeviceError` is a `WebastoModbusError` subclass (so the broad handlers still catch it); `_describe_modbus_response` maps known exception codes to names, handles unknown codes, and falls back to `str()`.
* **`tests/test_entities.py`** — a write-only number (`set_current_a`) seeds its value from the wallbox on add and skips the restore/re-apply fallback; the connectivity `binary_sensor` stays `available` and `is_on` tracks `coordinator.last_update_success` (correct `unique_id` / `translation_key`).
* **`tests/test_coordinator.py`** — a previously-failed REST setup is retried from the data poll once `_rest_setup_retry_at` has passed (and not before); a 401 on the REST login raises a repair issue and disables REST *without* scheduling a retry; a successful REST connect clears the repair issue.

Not covered (deliberately — would need driving the fake pymodbus client through error responses, riskier to write without local runs): the `_async_read_data_once` "bail on the first failing block" path and `_call_with_retry`'s no-reconnect-on-device-error behaviour. Those could be a later addition.

## Test plan
- [ ] CI green (these new tests pass under pytest)

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_