### PR TITLE
chore: finalize 1.1.7 changelog + clamp restored number value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.1.7] - 2026-05-11
+## [1.1.7] - 2026-05-12
 
 ### Added
 
@@ -33,6 +33,7 @@
 - Replaced a few private-attribute accesses with public accessors: external code now uses `WebastoDataCoordinator.rest_client` and `ModbusBridge.host` / `ModbusBridge.unit_id`.
 - Bumped README maintenance badge to 2026.
 - Documented the dependency-pinning conventions in `AGENTS.md` (`manifest.json` lists only packages HA core does not provide; `pymodbus` stays pinned to `<3.12`).
+- CI: third-party GitHub Actions are pinned to commit SHAs (with `# vX.Y.Z` comments so Dependabot still tracks them), and `dependabot.yml` was tightened (direct deps only, `pymodbus` major/minor held, grouped updates).
 - Release workflow: pre-release tags (`v*-beta.*`, `v*-rc.*`, …) are now published as GitHub pre-releases so HACS only offers them under "Show beta versions".
 
 ## [1.1.6] - 2026-05-11

--- a/custom_components/webasto_next_modbus/number.py
+++ b/custom_components/webasto_next_modbus/number.py
@@ -113,16 +113,19 @@ class WebastoNumber(WebastoRegisterEntity, RestoreNumber, NumberEntity):  # type
                 current_max = float(variant_max_current)
             self._attr_native_max_value = float(min(current_max, variant_max_current))
 
+    def _clamp_to_bounds(self, value: int) -> int:
+        """Clamp an integer value to the entity's native min/max."""
+
+        if self._attr_native_min_value is not None:
+            value = max(value, int(self._attr_native_min_value))
+        if self._attr_native_max_value is not None:
+            value = min(value, int(self._attr_native_max_value))
+        return value
+
     async def async_set_native_value(self, value: float) -> None:
         """Write a value to the Modbus register."""
 
-        int_value = int(round(value))
-
-        if self._attr_native_min_value is not None:
-            int_value = max(int_value, int(self._attr_native_min_value))
-        if self._attr_native_max_value is not None:
-            int_value = min(int_value, int(self._attr_native_max_value))
-
+        int_value = self._clamp_to_bounds(int(round(value)))
         await self._async_write_register(int_value)
         self._last_written_value = int_value
         self._attr_native_value = int_value
@@ -156,8 +159,11 @@ class WebastoNumber(WebastoRegisterEntity, RestoreNumber, NumberEntity):  # type
             last_number_data = await self.async_get_last_number_data()
             if last_number_data and last_number_data.native_value is not None:
                 try:
-                    self._last_written_value = int(round(float(last_number_data.native_value)))
-                    self._attr_native_value = float(self._last_written_value)
+                    restored = self._clamp_to_bounds(
+                        int(round(float(last_number_data.native_value)))
+                    )
+                    self._last_written_value = restored
+                    self._attr_native_value = float(restored)
                 except TypeError, ValueError:
                     _LOGGER.debug(
                         "Ignoring invalid restored value %s for %s",
@@ -219,11 +225,7 @@ class WebastoNumber(WebastoRegisterEntity, RestoreNumber, NumberEntity):  # type
             return False
         if not isinstance(value, (int, float)):
             return False
-        int_value = int(round(value))
-        if self._attr_native_min_value is not None:
-            int_value = max(int_value, int(self._attr_native_min_value))
-        if self._attr_native_max_value is not None:
-            int_value = min(int_value, int(self._attr_native_max_value))
+        int_value = self._clamp_to_bounds(int(round(value)))
         self._last_written_value = int_value
         self._attr_native_value = float(int_value)
         if self.hass is not None:


### PR DESCRIPTION
Prep for the `v1.1.7` stable release + one Copilot follow-up.

- `CHANGELOG.md`: set the `[1.1.7]` date to 2026-05-12; added an Internal note about the CI action SHA-pinning / `dependabot.yml` tightening (PR #49) that wasn't recorded yet.
- `number.py`: clamp the restored write-only value to the entity's min/max on startup (Copilot note on #54 — a value left over from a wider power variant could briefly show out of range before the background re-assert). Extracted the existing min/max clamp into `_clamp_to_bounds()` and reuse it everywhere (`async_set_native_value`, `_async_seed_from_wallbox`, the restore path).

The `## [1.1.7]` section is what the release workflow turns into the GitHub release notes, so once this is in `main` you can tag `v1.1.7`.

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt