### PR TITLE
ci: use the Unreleased changelog section for pre-release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,15 +43,22 @@ jobs:
       - name: Extract release notes
         id: extract_release_notes
         run: |
-          # Get the tag name (e.g., v0.4.0-beta.9)
+          # Get the tag name (e.g., v1.2.0-beta.1)
           TAG_NAME=${GITHUB_REF#refs/tags/}
-          # Remove 'v' prefix to match changelog version (e.g., 0.4.0-beta.9)
+          # Remove 'v' prefix to match changelog version (e.g., 1.2.0-beta.1)
           VERSION=${TAG_NAME#v}
-          
+
+          # Pre-release tags (anything with a '-', e.g. -beta.1) don't get their
+          # own changelog section, so pull the "Unreleased" section instead.
+          SECTION="$VERSION"
+          case "$TAG_NAME" in
+            *-*) SECTION="Unreleased" ;;
+          esac
+
           # Extract the section from CHANGELOG.md
           # Find the line with the version, print until the next version header
-          sed -n "/## \[$VERSION\]/,/## \[/p" CHANGELOG.md | sed '1d;$d' > RELEASE_NOTES.md
-          
+          sed -n "/## \[$SECTION\]/,/## \[/p" CHANGELOG.md | sed '1d;$d' > RELEASE_NOTES.md
+
           # If empty (e.g. first release or format mismatch), fallback to simple message
           if [ ! -s RELEASE_NOTES.md ]; then
             echo "Release $TAG_NAME" > RELEASE_NOTES.md


### PR DESCRIPTION
## Why

Pre-release tags (`v*-beta.*`, `v*-rc.*`) don't have a matching `## [x.y.z-beta.N]` section in `CHANGELOG.md` (we keep a single `## [Unreleased]` section per Keep a Changelog). So the release workflow's note extraction came up empty and fell back to a bare "Release v...".

## What

In the "Extract release notes" step: if the tag contains a `-` (i.e. it's a pre-release), read the `## [Unreleased]` section instead of `## [<version>]`. Stable tags are unchanged (they still use their own version section). The empty-result fallback is kept as a safety net.

Result: betas get the real "what's in this release" notes from `[Unreleased]`, and we never have to rename changelog headers just to get useful pre-release notes.

## Test plan

- [ ] Tag a `v*-beta.*` → release notes contain the `[Unreleased]` bullets.
- [ ] Tag a stable `vX.Y.Z` → release notes contain the `[X.Y.Z]` bullets (unchanged behaviour).

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_