### PR TITLE
docs: fix stale maintainer/architecture docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ Welcome! This folder collects the human-facing documentation for the Webasto Nex
 ## Getting started
 
 - **User guide** – The top-level [`README.md`](../README.md) covers installation (HACS and manual), configuration, entity overviews, and troubleshooting tips.
-- **Quick install notes** – The [Quick start](../README.md#quick-start) section shows the fastest path from checkout to a running integration.
+- **Install** – The [Installation](../README.md#installation) section shows the fastest path from checkout to a running integration.
 
 ## Deep dives
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,12 +77,12 @@ The register ranges are derived from community research and vendor documentation
 ## Software components
 
 - `__init__.py` – Integration setup/teardown, service registration, and coordinator bootstrap. Handles connection retries and starts the Life Bit loop.
-- `const.py` – Constants, version metadata, register descriptions, and enum mappings.
+- `const.py` – Constants, register descriptions, and enum mappings. The integration version lives in `manifest.json` / `pyproject.toml`, not here.
 - `hub.py` – `ModbusBridge` abstraction that wraps the async client, handles reconnect logic, exposes read/write helpers, and manages the background "Life Bit" loop.
 - `rest_client.py` – `WebastoRestClient` for optional REST API communication. Handles JWT authentication, token refresh, and API calls for features not available via Modbus.
 - `coordinator.py` – `DataUpdateCoordinator` implementation that schedules read cycles, normalises raw register values, and optionally fetches REST API data.
 - `config_flow.py` – User and options flows with validation and duplicate protection. Includes optional REST API credential configuration.
-- Platform modules (`sensor.py`, `number.py`, `button.py`, `switch.py`) – Entity classes backed by static descriptions. The switch platform provides REST-only entities like free charging toggle.
+- Platform modules (`sensor.py`, `number.py`, `button.py`, `switch.py`, `binary_sensor.py`, `text.py`) – Entity classes backed by static descriptions. `binary_sensor.py` exposes the always-available **Connected** connectivity sensor; the `switch`/`text` platforms provide REST-backed entities (free-charging toggle and tag ID).
 - `services.yaml` – Service schemas surfaced to Home Assistant.
 
 ## Data flow
@@ -100,7 +100,7 @@ The register ranges are derived from community research and vendor documentation
 
 ## Error handling
 
-- **Connection Retries**: During setup, the integration attempts to connect 3 times with a delay, notifying the user if it fails.
+- **Connection Retries**: During setup, the integration attempts to connect up to 5 times with a delay, notifying the user if it fails.
 - **Communication errors**: Raise `UpdateFailed`, automatically retried by the coordinator on the next polling interval.
 - **Individual register errors**: Logged and surfaced as `None` without blocking the entire payload.
 - **Write helpers**: Clamp values to safe ranges and surface validation errors back to the UI.

--- a/docs/development.md
+++ b/docs/development.md
@@ -65,9 +65,9 @@ If you want to run a specific check individually, you can use the `uv run <tool>
 
 1. **Update Version**:
 
-   - Bump version in `custom_components/webasto_next_modbus/manifest.json`.
-   - Bump version in `custom_components/webasto_next_modbus/const.py` (`INTEGRATION_VERSION`).
-   - Update `CHANGELOG.md`.
+   - Bump `version` in `custom_components/webasto_next_modbus/manifest.json`.
+   - Bump `version` in `pyproject.toml` (keep it in sync with the manifest).
+   - Move the `## [Unreleased]` section in `CHANGELOG.md` to the new `## [X.Y.Z] - YYYY-MM-DD` (the release notes are generated from this section).
 
 1. **Verify**:
 
@@ -79,9 +79,9 @@ If you want to run a specific check individually, you can use the `uv run <tool>
 
 1. **Tag & Release**:
 
-   - Create a signed tag: `git tag -s vX.Y.Z -m "Release vX.Y.Z"`
-   - Push: `git push origin vX.Y.Z`
-   - Create a GitHub Release (auto-generates notes).
+   - Create the tag: `git tag -a vX.Y.Z -m "vX.Y.Z"` and push it: `git push origin vX.Y.Z`.
+   - The **Release** workflow runs on the tag: it lints, tests, builds the `webasto_next_modbus.zip`, extracts the matching `CHANGELOG.md` section, and publishes the GitHub Release automatically.
+   - For a pre-release, use a tag with a suffix (e.g. `vX.Y.Z-beta.1`); the workflow marks it as a GitHub pre-release (HACS offers it only under "Show beta versions") and pulls notes from the `[Unreleased]` section.
 
 1. **Branding**:
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,8 +1,6 @@
-# 🆘 Support & Troubleshooting
+# Support & Troubleshooting
 
-Need help? We've got you covered.
-
-## 🔍 Before Opening a Ticket
+## Before Opening a Ticket
 
 1. **Check the Basics**: Ensure your wallbox is powered on and reachable via network.
 
@@ -22,7 +20,7 @@ Need help? We've got you covered.
        custom_components.webasto_next_modbus: debug
    ```
 
-## 💬 Where to Ask
+## Where to Ask
 
 | Topic | Channel |
 | :--- | :--- |
@@ -30,11 +28,11 @@ Need help? We've got you covered.
 | **"It's broken!"** | [GitHub Issues](https://github.com/tomwellnitz/Webasto-Next-Modbus/issues) (Please attach diagnostics!) |
 | **"I have an idea!"** | [Feature Requests](https://github.com/tomwellnitz/Webasto-Next-Modbus/issues) |
 
-## ⚠️ Known Limitations
+## Known Limitations
 
 - **Dynamic IP**: The integration expects a static IP. Please configure a DHCP reservation for your wallbox.
 - **Old Firmware**: Firmware < 3.1 might not support all features (like Keepalive).
 
-## 🔒 Security
+## Security
 
 Found a vulnerability? Please report it via **GitHub Security Advisories** or open a private issue if available. Do not post public exploits.


### PR DESCRIPTION
Follow-up to the README cleanup (#57): fixes stale content in the maintainer/architecture docs.

- **`docs/development.md`** release playbook: drop the `INTEGRATION_VERSION` (`const.py`) bump — that constant was removed in 1.1.7; add `pyproject.toml` (it carries its own version, kept in sync with the manifest); and document that the **Release** workflow auto-publishes the GitHub release from the matching `CHANGELOG.md` section, including the pre-release/beta path (`-beta.N` tags → GitHub pre-release, notes from `[Unreleased]`).
- **`docs/README.md`** (portal): fix the dead `../README.md#quick-start` anchor (the heading is now `## Installation`).
- **`docs/architecture.md`**: list the `binary_sensor.py` and `text.py` platforms (the **Connected** sensor and the free-charging tag-id text were missing); drop the stale "version metadata" note on `const.py`; correct the setup connect-retry count (3 → 5, matching `MAX_RETRY_ATTEMPTS`).
- **`docs/support.md`**: drop the heading emoji to match the README's style.

Left as-is: `docs/rest-api.md` (external wallbox API spec) and `docs/rest-api-integration-plan.md` (roadmap/plan, historical).

`codespell` passes; all internal links resolve.

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_