### PR TITLE
ci: auto-merge low-risk dependabot PRs + release cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    # Wait a few days after a release before opening a PR. Avoids churn from
+    # same-week double-bumps (e.g. a release that gets a hotfix the next day)
+    # and gives upstream time to yank a bad version. Security updates ignore
+    # the cooldown and still arrive immediately.
+    cooldown:
+      default-days: 7
     # Only direct dependencies declared in pyproject.toml; there is no lock
     # file, so transitive bumps would just be noise.
     allow:
@@ -37,6 +43,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,35 @@
+name: Dependabot auto-merge
+
+# Auto-merges low-risk Dependabot PRs (patch + minor) once all required status
+# checks pass. Major bumps are left for manual review. Auto-merge only takes
+# effect when the repository has "Allow auto-merge" enabled and `main` is
+# protected with required status checks (CI + CodeQL) — otherwise GitHub would
+# merge immediately without waiting for CI. See AGENTS.md / repository settings.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # For grouped PRs, update-type is the highest semver bump in the group,
+      # so a group containing a major bump is correctly held for manual review.
+      - name: Enable auto-merge for patch and minor updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,14 @@ This script executes:
 - Where a package appears in **both** `pyproject.toml` and `manifest.json` (i.e. `pymodbus`), the version specifiers must stay in sync — HACS / hassfest validation flags drift. Update both in the same commit.
 - `pymodbus` is pinned to `>=3.11.2,<3.12` to match the version Home Assistant core's built-in `modbus` integration pins. Do **not** loosen this bound without first checking that HA core's pin has moved — pymodbus 3.12+ removed `ModbusDeviceContext.store`/`decode` and added a `SimDevice` validator that breaks our virtual wallbox.
 
+### 6. Dependabot & auto-merge
+
+- `dependabot.yml` keeps PRs low-noise: direct deps only, grouped per ecosystem, a 7-day `cooldown`, `pymodbus` major/minor and `homeassistant` / `pytest-homeassistant-custom-component` patch bumps ignored (they just track HA point releases).
+- `.github/workflows/dependabot-auto-merge.yml` enables GitHub auto-merge for **patch + minor** Dependabot PRs; **major** bumps are left for manual review. For grouped PRs the highest semver bump in the group decides.
+- **Two repository settings are required for auto-merge to be safe**, otherwise GitHub would merge without waiting for CI:
+  1. Settings → General → **Allow auto-merge** (enabled).
+  1. Settings → Branches → branch protection on `main` with **required status checks** (`build`, `validate`, CodeQL `Analyze`). Do **not** require pull-request approvals — Dependabot cannot approve its own PR, which would deadlock auto-merge on a solo-maintainer repo.
+
 ## 🧪 Testing Strategy
 
 - **Unit Tests**: Cover all config flows, sensor parsing, and coordinator logic.


### PR DESCRIPTION
## Summary

Makes the Dependabot setup hands-off for the boring updates while keeping major bumps under manual review.

**Auto-merge (`.github/workflows/dependabot-auto-merge.yml`)**
- Enables GitHub auto-merge for **patch + minor** Dependabot PRs once required checks pass; **major** bumps are left for manual review.
- Uses `dependabot/fetch-metadata` (SHA-pinned to v3.1.0) + `gh pr merge --auto --squash`.
- For grouped PRs the highest semver bump in the group decides, so a group containing a major bump is held back.
- Minimal `permissions` (`contents: write`, `pull-requests: write`); `pull_request` event, no code checkout.

**Release cooldown (`dependabot.yml`)**
- 7-day `cooldown` on both ecosystems so PRs only open once a release has settled — kills the same-week double-bump churn (e.g. the `0.13.331` → `0.13.332` next-day bump). Security updates bypass the cooldown.

**Docs (`AGENTS.md`)**
- New "Dependabot & auto-merge" section documenting the **two required repo settings**, without which auto-merge would merge *without* a CI gate:
  1. Settings → General → **Allow auto-merge**
  2. Branch protection on `main` with **required status checks** (`build`, `validate`, CodeQL `Analyze`), and **no** required PR approvals (Dependabot can't approve its own PR → would deadlock).

## Required before this is effective

- [ ] Enable "Allow auto-merge" in repo settings
- [ ] Add/confirm branch protection on `main` with required status checks (no approval requirement)

## Test plan

- [x] Both YAML files parse (`yaml.safe_load`)
- [x] `.github/` is excluded from yamllint, so CI is unaffected
- [ ] On the next Dependabot patch/minor PR: workflow runs, auto-merge is enabled, PR merges after CI is green
- [ ] On a major bump: workflow runs but does not enable auto-merge

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_