### PR TITLE
refactor(blueprints): modernise to 2026 plural-key syntax

### DIFF
--- a/blueprints/automation/webasto_next_modbus/charge_target.yaml
+++ b/blueprints/automation/webasto_next_modbus/charge_target.yaml
@@ -1,6 +1,6 @@
 ---
 blueprint:
-  name: Webasto Next – Charge Target (kWh)
+  name: Webasto Next / Unite – Charge Target (kWh)
   description: >-
     Charges the vehicle for a specific amount of energy (kWh) and then stops.
     Requires an Input Number helper (for the target amount) and an Input Boolean
@@ -8,7 +8,7 @@ blueprint:
   domain: automation
   input:
     webasto_device:
-      name: Webasto Next Wallbox
+      name: Webasto Next / Unite wallbox
       description: The wallbox device to control.
       selector:
         device:
@@ -50,12 +50,12 @@ blueprint:
 mode: restart
 max_exceeded: silent
 
-trigger:
-  - platform: state
+triggers:
+  - trigger: state
     entity_id: !input active_switch_helper
     to: "on"
     id: "start"
-  - platform: state
+  - trigger: state
     entity_id: !input session_energy_sensor
     id: "update"
 
@@ -63,21 +63,10 @@ variables:
   webasto_device: !input webasto_device
   notify_device: !input notify_device
   target_kwh: !input target_kwh_helper
-  active_switch: !input active_switch_helper
   energy_sensor: !input session_energy_sensor
-  # Store the start energy in a variable when the switch is turned on?
-  # Blueprints are stateless across restarts, but variables are local to the
-  # run.
-  # We need a way to know the "start" value.
-  # A robust way is to reset the session energy on the wallbox, but we can't
-  # always do that. Alternatively, we assume "Session Energy" sensor starts at 0
-  # or near 0 for a new session. If the user uses the "Session Energy" sensor
-  # from the integration, it resets on new session start.
-  # So we can just check if session_energy >= target.
 
-action:
+actions:
   - choose:
-      # Case 1: User turned the switch ON -> Start charging
       - conditions:
           - condition: trigger
             id: "start"
@@ -86,21 +75,17 @@ action:
             data:
               config_entry_id: >-
                 {{ device_attr(webasto_device, 'config_entries')[0] }}
-
-      # Case 2: Energy updated -> Check if target reached
       - conditions:
           - condition: trigger
             id: "update"
           - condition: state
             entity_id: !input active_switch_helper
             state: "on"
+          # The integration reports session energy in Wh; the target is in kWh.
           - condition: template
-            # Check if current session energy >= target
             value_template: >-
               {{ states(energy_sensor) | float(0) / 1000 >=
                  states(target_kwh) | float(0) }}
-              {# Note: Integration provides Wh, input_number is usually kWh. #}
-              {# The integration sensor 'meter_reading_session' is in Wh. #}
         sequence:
           - action: webasto_next_modbus.stop_session
             data:

--- a/blueprints/automation/webasto_next_modbus/charge_until_full.yaml
+++ b/blueprints/automation/webasto_next_modbus/charge_until_full.yaml
@@ -1,6 +1,6 @@
 ---
 blueprint:
-  name: Webasto Next – Charge Until Full (Auto-Stop)
+  name: Webasto Next / Unite – Charge Until Full (Auto-Stop)
   description: >-
     Automatically stops the charging session when the power drops below a
     threshold for a set duration, indicating the battery is full.
@@ -8,7 +8,7 @@ blueprint:
   domain: automation
   input:
     webasto_device:
-      name: Webasto Next Wallbox
+      name: Webasto Next / Unite wallbox
       description: The wallbox device to control.
       selector:
         device:
@@ -53,29 +53,21 @@ blueprint:
         device:
           integration: mobile_app
 
-# Blueprint inputs are not available inside templates directly; expose the ones
-# used in templates here first.
+# Inputs used in templates must be exposed as variables first.
 variables:
   webasto_device: !input webasto_device
   notify_device: !input notify_device
 
-trigger:
-  - platform: numeric_state
+triggers:
+  - trigger: numeric_state
     entity_id: !input power_sensor
     below: !input power_threshold
     for:
       minutes: !input duration
 
-condition:
-  # Only stop if we are actually in a charging session.
-  # We can check the power sensor itself (redundant but safe) or just assume the
-  # trigger is enough. Better: Check if the wallbox status is 'Charging' (IEC
-  # State C). But accessing that specific entity via device selector is hard in
-  # blueprints without asking for it explicitly.
-  # We'll rely on the power drop trigger.
-  []
+conditions: []
 
-action:
+actions:
   - action: webasto_next_modbus.stop_session
     data:
       config_entry_id: >-

--- a/blueprints/automation/webasto_next_modbus/fastcharge_fullcharge.yaml
+++ b/blueprints/automation/webasto_next_modbus/fastcharge_fullcharge.yaml
@@ -41,19 +41,19 @@ variables:
   webasto_device: !input webasto_device
   reset_helpers: !input reset_helpers
 
-trigger:
-  - platform: state
+triggers:
+  - trigger: state
     entity_id: !input fastcharge_helper
     to: "on"
     id: start
-  - platform: state
+  - trigger: state
     entity_id: !input fullcharge_helper
     to: "on"
     id: stop
 
-condition: []
+conditions: []
 
-action:
+actions:
   - choose:
       - conditions:
           - condition: trigger

--- a/blueprints/automation/webasto_next_modbus/solar_optimizer.yaml
+++ b/blueprints/automation/webasto_next_modbus/solar_optimizer.yaml
@@ -1,6 +1,6 @@
 ---
 blueprint:
-  name: Webasto Next – Solar Surplus Optimizer
+  name: Webasto Next / Unite – Solar Surplus Optimizer
   description: >-
     Adjusts the charging current based on grid export/import to maximize solar
     self-consumption. Requires a grid power sensor (negative = export, positive
@@ -58,8 +58,8 @@ blueprint:
 mode: restart
 max_exceeded: silent
 
-trigger:
-  - platform: state
+triggers:
+  - trigger: state
     entity_id: !input grid_sensor
 
 variables:
@@ -89,10 +89,10 @@ variables:
   # Round down to be safe (avoid importing)
   target_amps: "{{ target_amps_raw | int }}"
 
-action:
+actions:
+  # Only writes when the computed current actually changes, so a noisy grid
+  # sensor does not produce redundant Modbus writes.
   - choose:
-      # Only update if the target amps are within range and different from
-      # current
       - conditions:
           - condition: template
             value_template: >-


### PR DESCRIPTION
## Summary (PR B of the blueprint rework)

Brings all four blueprints up to the **current Home Assistant style** (documented since 2024.10). The old singular keys still work indefinitely, so this is a non-breaking modernisation:

- `triggers:` / `conditions:` / `actions:` instead of `trigger:` / `condition:` / `action:`
- `- trigger: <platform>` instead of `- platform: <platform>`
- Integration named **"Webasto Next / Unite"** consistently across all four
- Dropped the leftover development-note comment blocks (e.g. the variables-block essay in `charge_target`, the rambling empty-condition note in `charge_until_full`); kept the few that explain a non-obvious choice (Wh→kWh conversion; change-gated solar writes)

**No behavioural change.** `solar_optimizer` already writes only when the computed current actually changes (`target_amps != current_setpoint`), so a noisy grid sensor does not cause redundant Modbus writes — no extra debounce needed.

Follows #64 (A: fixed the broken `inputs`/`i()` templates). Next: **C** — a new device-trigger notification blueprint built on the integration's five device triggers (`charging_started`, `charging_stopped`, `connection_lost`, `connection_restored`, `keepalive_sent`).

## Test plan

- [x] `yamllint .` clean; all four parse; `triggers:`/`actions:` present, no singular keys or `platform:` left (verified locally)
- [x] `tests/test_blueprints.py` footgun lint still clean
- [ ] CI green on 3.14.2

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_