### PR TITLE
feat(blueprints): add event notification blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Ready-to-import blueprints live under **Settings → Automations & Scenes → Bl
 - **Charge target (kWh)** — charge a set amount of energy, then stop.
 - **Charge until full** — stop automatically once charging power drops below a threshold.
 - **Solar surplus optimizer** — adjust the charging current to grid export to maximise self-consumption.
+- **Event notifications** — send a mobile notification on charging or connectivity events (charging started/stopped, connection lost/restored, keep-alive sent).
 
 Device triggers for charging start/stop and connection state are available for your own automations.
 

--- a/blueprints/automation/webasto_next_modbus/event_notifications.yaml
+++ b/blueprints/automation/webasto_next_modbus/event_notifications.yaml
@@ -1,0 +1,95 @@
+---
+blueprint:
+  name: Webasto Next / Unite – Event notifications
+  description: >-
+    Sends a mobile notification when the wallbox reports a charging or
+    connectivity event (charging started/stopped, connection lost/restored,
+    keep-alive sent). Pick which events you want to be notified about.
+  domain: automation
+  input:
+    webasto_device:
+      name: Webasto Next / Unite wallbox
+      description: The wallbox to watch.
+      selector:
+        device:
+          integration: webasto_next_modbus
+    notify_device:
+      name: Notification device
+      description: The mobile device to notify (Home Assistant companion app).
+      selector:
+        device:
+          integration: mobile_app
+    events:
+      name: Events to notify about
+      description: Which wallbox events should trigger a notification.
+      default:
+        - charging_started
+        - charging_stopped
+        - connection_lost
+        - connection_restored
+      selector:
+        select:
+          multiple: true
+          options:
+            - label: Charging started
+              value: charging_started
+            - label: Charging stopped
+              value: charging_stopped
+            - label: Connection lost
+              value: connection_lost
+            - label: Connection restored
+              value: connection_restored
+            - label: Keep-alive sent
+              value: keepalive_sent
+
+mode: queued
+max_exceeded: silent
+
+# Inputs used in templates must be exposed as variables first.
+variables:
+  webasto_device: !input webasto_device
+  selected_events: !input events
+  event_titles:
+    charging_started: Charging started
+    charging_stopped: Charging stopped
+    connection_lost: Connection lost
+    connection_restored: Connection restored
+    keepalive_sent: Keep-alive sent
+
+triggers:
+  - trigger: device
+    domain: webasto_next_modbus
+    device_id: !input webasto_device
+    type: charging_started
+    id: charging_started
+  - trigger: device
+    domain: webasto_next_modbus
+    device_id: !input webasto_device
+    type: charging_stopped
+    id: charging_stopped
+  - trigger: device
+    domain: webasto_next_modbus
+    device_id: !input webasto_device
+    type: connection_lost
+    id: connection_lost
+  - trigger: device
+    domain: webasto_next_modbus
+    device_id: !input webasto_device
+    type: connection_restored
+    id: connection_restored
+  - trigger: device
+    domain: webasto_next_modbus
+    device_id: !input webasto_device
+    type: keepalive_sent
+    id: keepalive_sent
+
+conditions:
+  - condition: template
+    value_template: "{{ trigger.id in selected_events }}"
+
+actions:
+  - device_id: !input notify_device
+    domain: mobile_app
+    type: notify
+    title: "{{ device_attr(webasto_device, 'name') }}"
+    message: "{{ event_titles[trigger.id] }}"


### PR DESCRIPTION
## Summary (PR C of the blueprint rework)

Adds a new **Event notifications** blueprint — the first one to use the device triggers the integration already exposes (`device_trigger.py`).

- Sends a mobile (companion-app) notification when the wallbox reports a charging or connectivity event.
- A multi-select lets the user pick which of the five events to be notified about: charging started, charging stopped, connection lost, connection restored, keep-alive sent.
- Built in the 2026 style (`triggers:`/`conditions:`/`actions:`, `trigger: device`), inputs exposed via `variables:` + `!input` (passes the `test_blueprints.py` lint).
- Documented in the README blueprint list.

Completes the blueprint rework: A (#64, fix broken templates) → B (#65, modernise syntax) → **C** (this, new trigger-based blueprint).

## Test plan

- [x] `yamllint` + `codespell` clean; parses to 5 device triggers + condition + action; no `inputs.`/`i(` footguns (verified locally)
- [ ] CI green on 3.14.2
- [ ] Manual: import blueprint, pick a wallbox + phone, trigger a charging start → notification arrives

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_