### PR TITLE
feat(config-flow): add reauth flow for REST API credentials

### DIFF
--- a/.vulture_whitelist.py
+++ b/.vulture_whitelist.py
@@ -8,6 +8,7 @@ async_step_user  # unused method
 async_step_zeroconf  # unused method
 async_get_options_flow  # unused method
 async_step_init  # unused method
+entry_data  # unused arg required by Home Assistant's async_step_reauth signature
 INTEGRATION_VERSION  # unused variable
 entity  # unused variable
 PHASE_COUNT_MAP  # unused variable

--- a/custom_components/webasto_next_modbus/config_flow.py
+++ b/custom_components/webasto_next_modbus/config_flow.py
@@ -239,6 +239,72 @@ class WebastoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(step_id="reconfigure", data_schema=data_schema)
 
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> config_entries.ConfigFlowResult:
+        """Handle re-authentication when the REST API rejects the credentials."""
+
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: Mapping[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Ask the user for new REST API credentials and validate them."""
+
+        from .rest_client import AuthenticationError
+
+        entry = self._get_reauth_entry()
+        errors: dict[str, str] = {}
+        current_username = entry.options.get(
+            CONF_REST_USERNAME, entry.data.get(CONF_REST_USERNAME, DEFAULT_REST_USERNAME)
+        )
+
+        if user_input is not None:
+            username = str(user_input.get(CONF_REST_USERNAME, current_username)).strip()
+            password = str(user_input.get(CONF_REST_PASSWORD, ""))
+            try:
+                await self._async_validate_rest(entry.data[CONF_HOST], username, password)
+            except AuthenticationError:
+                errors["base"] = "invalid_auth"
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.warning("REST API validation failed during reauth: %s", err)
+                errors["base"] = "rest_cannot_connect"
+            else:
+                new_options = dict(entry.options)
+                new_options[CONF_REST_ENABLED] = True
+                new_options[CONF_REST_USERNAME] = username
+                new_options[CONF_REST_PASSWORD] = password
+                return self.async_update_reload_and_abort(entry, options=new_options)
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_REST_USERNAME, default=current_username): selector.TextSelector(
+                    selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+                ),
+                vol.Required(CONF_REST_PASSWORD): selector.TextSelector(
+                    selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+                ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=data_schema,
+            errors=errors,
+            description_placeholders={"host": entry.data.get(CONF_HOST, "")},
+        )
+
+    async def _async_validate_rest(self, host: str, username: str, password: str) -> None:
+        """Open a REST session to confirm the credentials, then close it."""
+
+        from .rest_client import RestClient
+
+        client = RestClient(host, username, password)
+        try:
+            await client.connect()
+        finally:
+            await client.disconnect()
+
     async def _async_validate_and_connect(self, data: Mapping[str, Any]) -> None:
         """Validate user input by performing a Modbus test read."""
         host = data[CONF_HOST]

--- a/custom_components/webasto_next_modbus/coordinator.py
+++ b/custom_components/webasto_next_modbus/coordinator.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.components import persistent_notification
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -38,9 +37,6 @@ if TYPE_CHECKING:
     from .rest_client import RestClient, RestData
 
 _LOGGER = logging.getLogger(__name__)
-
-# Repair-issue key for "REST credentials rejected".
-ISSUE_REST_AUTH = "rest_auth_failed"
 
 
 class WebastoDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -112,16 +108,17 @@ class WebastoDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             await self._rest_client.connect()
             _LOGGER.info("REST API client connected successfully")
             self._rest_setup_retry_at = None
-            self._clear_rest_auth_issue()
         except AuthenticationError as err:
             _LOGGER.warning("REST API authentication failed: %s", err)
             with contextlib.suppress(Exception):
                 await self._rest_client.disconnect()
             self._rest_client = None
-            # Wrong credentials won't fix themselves by retrying — surface a
-            # repair issue so the user updates them in the options.
+            # Wrong credentials won't fix themselves by retrying — start a
+            # reauth flow so the user can enter new ones. The Modbus side keeps
+            # working regardless.
             self._rest_setup_retry_at = None
-            self._raise_rest_auth_issue()
+            if self.config_entry is not None:
+                self.config_entry.async_start_reauth(self.hass)
         except Exception as err:  # noqa: BLE001
             _LOGGER.warning("Failed to connect REST API client: %s", err)
             with contextlib.suppress(Exception):
@@ -130,25 +127,8 @@ class WebastoDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # The wallbox may just be booting; retry later from the data poll.
             self._rest_setup_retry_at = datetime.now(UTC) + self._rest_setup_retry_interval
 
-    def _rest_auth_issue_id(self) -> str:
-        return f"{ISSUE_REST_AUTH}_{self.entry_id}"
-
-    def _raise_rest_auth_issue(self) -> None:
-        ir.async_create_issue(
-            self.hass,
-            DOMAIN,
-            self._rest_auth_issue_id(),
-            is_fixable=False,
-            severity=ir.IssueSeverity.ERROR,
-            translation_key=ISSUE_REST_AUTH,
-        )
-
-    def _clear_rest_auth_issue(self) -> None:
-        ir.async_delete_issue(self.hass, DOMAIN, self._rest_auth_issue_id())
-
     async def async_shutdown_rest_client(self) -> None:
-        """Disconnect the REST client and clear any REST repair issue."""
-        self._clear_rest_auth_issue()
+        """Disconnect the REST client."""
         if self._rest_client is not None:
             await self._rest_client.disconnect()
             self._rest_client = None

--- a/custom_components/webasto_next_modbus/translations/de.json
+++ b/custom_components/webasto_next_modbus/translations/de.json
@@ -24,15 +24,26 @@
           "unit_id": "Unit-ID",
           "name": "Name (optional)"
         }
+      },
+      "reauth_confirm": {
+        "title": "REST-API neu authentifizieren",
+        "description": "Die Wallbox unter {host} hat die gespeicherten REST-API-Zugangsdaten abgelehnt. Bitte aktuellen Benutzernamen und Passwort eingeben.",
+        "data": {
+          "rest_username": "REST-API-Benutzername",
+          "rest_password": "REST-API-Passwort"
+        }
       }
     },
     "error": {
       "cannot_connect": "Verbindung fehlgeschlagen. Host, Port oder Modbus-Konfiguration prüfen.",
+      "invalid_auth": "Die Wallbox hat diese REST-API-Zugangsdaten abgelehnt.",
+      "rest_cannot_connect": "REST-API nicht erreichbar. Netzwerk prüfen und erneut versuchen.",
       "unknown": "Unerwarteter Fehler"
     },
     "abort": {
       "already_configured": "Diese Wallbox ist bereits eingerichtet.",
       "reconfigure_successful": "Die Verbindungseinstellungen wurden aktualisiert.",
+      "reauth_successful": "Die REST-API-Zugangsdaten wurden aktualisiert.",
       "missing_dependency": "Das benötigte Paket 'voluptuous' fehlt in dieser Home Assistant Umgebung."
     }
   },
@@ -285,12 +296,6 @@
     },
     "abort": {
       "missing_dependency": "Das benötigte Paket 'voluptuous' fehlt in dieser Home Assistant Umgebung."
-    }
-  },
-  "issues": {
-    "rest_auth_failed": {
-      "title": "Webasto Next: REST-API-Anmeldung fehlgeschlagen",
-      "description": "Der REST-API-Benutzername oder das Passwort werden von der Wallbox nicht mehr akzeptiert. Bitte in den Integrations-Optionen aktualisieren (Einstellungen → Geräte & Dienste → Webasto Next → Konfigurieren). Die Modbus-Seite läuft in der Zwischenzeit weiter."
     }
   }
 }

--- a/custom_components/webasto_next_modbus/translations/en.json
+++ b/custom_components/webasto_next_modbus/translations/en.json
@@ -24,15 +24,26 @@
           "unit_id": "Unit ID",
           "name": "Name (optional)"
         }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate REST API",
+        "description": "The wallbox at {host} rejected the stored REST API credentials. Enter the current username and password.",
+        "data": {
+          "rest_username": "REST API Username",
+          "rest_password": "REST API Password"
+        }
       }
     },
     "error": {
       "cannot_connect": "Failed to connect. Check host, port, and Modbus configuration.",
+      "invalid_auth": "The wallbox rejected these REST API credentials.",
+      "rest_cannot_connect": "Could not reach the REST API. Check the network and try again.",
       "unknown": "Unexpected error"
     },
     "abort": {
       "already_configured": "This wallbox is already configured.",
       "reconfigure_successful": "The connection settings were updated.",
+      "reauth_successful": "The REST API credentials were updated.",
       "missing_dependency": "Required package 'voluptuous' is missing in this Home Assistant environment."
     }
   },
@@ -284,12 +295,6 @@
       "phase_switch": {
         "name": "Three-phase charging"
       }
-    }
-  },
-  "issues": {
-    "rest_auth_failed": {
-      "title": "Webasto Next: REST API authentication failed",
-      "description": "The REST API username or password is no longer accepted by the wallbox. Update them in the integration options (Settings → Devices & Services → Webasto Next → Configure). The Modbus side keeps working in the meantime."
     }
   }
 }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -20,6 +20,8 @@ from custom_components.webasto_next_modbus.config_flow import (
 from custom_components.webasto_next_modbus.const import (
     CONF_MODEL,
     CONF_REST_ENABLED,
+    CONF_REST_PASSWORD,
+    CONF_REST_USERNAME,
     CONF_SCAN_INTERVAL,
     CONF_UNIT_ID,
     CONF_VARIANT,
@@ -30,6 +32,7 @@ from custom_components.webasto_next_modbus.const import (
     DEFAULT_VARIANT,
     VARIANT_22_KW,
 )
+from custom_components.webasto_next_modbus.rest_client import AuthenticationError
 
 pytestmark = pytest.mark.asyncio
 
@@ -293,3 +296,88 @@ async def test_options_flow_updates_interval() -> None:
         CONF_REST_ENABLED: False,
     }
     hass.config_entries.async_update_entry.assert_called_once()
+
+
+async def test_reauth_shows_form() -> None:
+    """The reauth step shows the credential form."""
+
+    entry = MockConfigEntry(
+        domain="webasto_next_modbus",
+        data={CONF_HOST: "192.0.2.3", CONF_PORT: DEFAULT_PORT, CONF_UNIT_ID: DEFAULT_UNIT_ID},
+        options={CONF_REST_ENABLED: True, CONF_REST_USERNAME: "admin"},
+        unique_id="192.0.2.3-255",
+    )
+
+    flow = WebastoConfigFlow()
+    flow.hass = MagicMock()
+
+    with patch.object(WebastoConfigFlow, "_get_reauth_entry", return_value=entry):
+        result = await flow.async_step_reauth_confirm()
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "reauth_confirm"
+
+
+async def test_reauth_updates_credentials() -> None:
+    """Reauth validates the new credentials and updates the entry options."""
+
+    entry = MockConfigEntry(
+        domain="webasto_next_modbus",
+        data={CONF_HOST: "192.0.2.3", CONF_PORT: DEFAULT_PORT, CONF_UNIT_ID: DEFAULT_UNIT_ID},
+        options={CONF_REST_ENABLED: True, CONF_REST_USERNAME: "admin"},
+        unique_id="192.0.2.3-255",
+    )
+
+    flow = WebastoConfigFlow()
+    flow.hass = MagicMock()
+
+    sentinel = {"type": FlowResultType.ABORT, "reason": "reauth_successful"}
+
+    with (
+        patch.object(WebastoConfigFlow, "_get_reauth_entry", return_value=entry),
+        patch.object(WebastoConfigFlow, "_async_validate_rest", AsyncMock()) as validate,
+        patch.object(
+            WebastoConfigFlow, "async_update_reload_and_abort", return_value=sentinel
+        ) as reload_abort,
+    ):
+        result = await flow.async_step_reauth_confirm(
+            {CONF_REST_USERNAME: "admin", CONF_REST_PASSWORD: "newpass"}
+        )
+
+    validate.assert_awaited_once()
+    reload_abort.assert_called_once()
+    _, kwargs = reload_abort.call_args
+    assert kwargs["options"][CONF_REST_USERNAME] == "admin"
+    assert kwargs["options"][CONF_REST_PASSWORD] == "newpass"
+    assert kwargs["options"][CONF_REST_ENABLED] is True
+    assert result is sentinel
+
+
+async def test_reauth_invalid_auth() -> None:
+    """Rejected credentials re-show the reauth form with invalid_auth."""
+
+    entry = MockConfigEntry(
+        domain="webasto_next_modbus",
+        data={CONF_HOST: "192.0.2.3", CONF_PORT: DEFAULT_PORT, CONF_UNIT_ID: DEFAULT_UNIT_ID},
+        options={CONF_REST_ENABLED: True, CONF_REST_USERNAME: "admin"},
+        unique_id="192.0.2.3-255",
+    )
+
+    flow = WebastoConfigFlow()
+    flow.hass = MagicMock()
+
+    with (
+        patch.object(WebastoConfigFlow, "_get_reauth_entry", return_value=entry),
+        patch.object(
+            WebastoConfigFlow,
+            "_async_validate_rest",
+            AsyncMock(side_effect=AuthenticationError("bad creds")),
+        ),
+    ):
+        result = await flow.async_step_reauth_confirm(
+            {CONF_REST_USERNAME: "admin", CONF_REST_PASSWORD: "wrong"}
+        )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "reauth_confirm"
+    assert result.get("errors") == {"base": "invalid_auth"}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -260,8 +260,8 @@ async def test_coordinator_force_refreshes_rest_data() -> None:
     assert coordinator.rest_data is sentinel
 
 
-async def test_coordinator_rest_auth_failure_raises_repair_issue() -> None:
-    """A 401 on the REST login surfaces a repair issue and disables REST (no retry)."""
+async def test_coordinator_rest_auth_failure_starts_reauth() -> None:
+    """A 401 on the REST login starts a reauth flow and disables REST (no retry)."""
 
     bridge = AsyncMock(spec=ModbusBridge)
     bridge.endpoint = "192.0.2.1:502 (device_id 255)"
@@ -273,7 +273,7 @@ async def test_coordinator_rest_auth_failure_raises_repair_issue() -> None:
     coordinator = _build_coordinator(bridge, entry)
 
     with (
-        patch("custom_components.webasto_next_modbus.coordinator.ir") as mock_ir,
+        patch.object(entry, "async_start_reauth") as start_reauth,
         patch("custom_components.webasto_next_modbus.rest_client.RestClient") as mock_rc,
     ):
         mock_rc.return_value.connect = AsyncMock(side_effect=AuthenticationError("bad creds"))
@@ -283,11 +283,11 @@ async def test_coordinator_rest_auth_failure_raises_repair_issue() -> None:
     assert coordinator._rest_client is None
     assert coordinator._rest_setup_retry_at is None
     mock_rc.return_value.disconnect.assert_awaited_once()
-    mock_ir.async_create_issue.assert_called_once()
+    start_reauth.assert_called_once()
 
 
-async def test_coordinator_clears_rest_auth_issue_on_success() -> None:
-    """A successful REST connect clears the auth repair issue."""
+async def test_coordinator_rest_success_does_not_start_reauth() -> None:
+    """A successful REST connect does not trigger a reauth flow."""
 
     bridge = AsyncMock(spec=ModbusBridge)
     bridge.endpoint = "192.0.2.1:502 (device_id 255)"
@@ -299,7 +299,7 @@ async def test_coordinator_clears_rest_auth_issue_on_success() -> None:
     coordinator = _build_coordinator(bridge, entry)
 
     with (
-        patch("custom_components.webasto_next_modbus.coordinator.ir") as mock_ir,
+        patch.object(entry, "async_start_reauth") as start_reauth,
         patch("custom_components.webasto_next_modbus.rest_client.RestClient") as mock_rc,
     ):
         mock_rc.return_value.connect = AsyncMock()
@@ -307,4 +307,4 @@ async def test_coordinator_clears_rest_auth_issue_on_success() -> None:
         await coordinator.async_setup_rest_client()
 
     assert coordinator._rest_client is mock_rc.return_value
-    mock_ir.async_delete_issue.assert_called_once()
+    start_reauth.assert_not_called()


### PR DESCRIPTION
## Summary (Tier 1b — toward Gold quality scale)

When the wallbox rejects the stored REST API credentials (HTTP 401), the integration now starts a **guided reauth flow** instead of raising a dead-end repair issue. The user enters new credentials, they're validated against the REST API, and the entry options are updated + reloaded. The Modbus side keeps working throughout (REST is optional/secondary).

- **config_flow**: `async_step_reauth` / `async_step_reauth_confirm` + a REST validation helper. Distinguishes `invalid_auth` (401) from a transient `rest_cannot_connect`. Validating REST is safe to probe — it's a separate HTTP subsystem, unaffected by the single-Modbus-connection limit.
- **coordinator**: replaces the `rest_auth_failed` repair issue (and its create/clear helpers + `issue_registry` import) with `config_entry.async_start_reauth`.
- **translations**: add the `reauth_confirm` step, `invalid_auth` / `rest_cannot_connect` errors and `reauth_successful` abort; drop the now-unused issue strings.
- **tests**: coordinator asserts reauth is started on 401 (and not on success); config-flow tests cover the reauth form, a successful credential update and `invalid_auth`.

Follows #67 (reconfigure flow). Together these are the Tier-1 quality-scale items (reconfigure + reauth).

## Test plan

- [x] ruff check + ruff format + yamllint + codespell clean (run locally with the real tools)
- [x] translations valid JSON; no orphan issue translation
- [ ] CI green on 3.14.2
- [ ] Manual: set a wrong REST password → reauth prompt appears → enter correct one → REST entities recover

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_