### PR TITLE
fix(config-flow): avoid double reload in reconfigure/reauth (2026.6 deprecation)

### DIFF
--- a/custom_components/webasto_next_modbus/config_flow.py
+++ b/custom_components/webasto_next_modbus/config_flow.py
@@ -198,12 +198,17 @@ class WebastoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 new_data.pop(CONF_NAME, None)
                 title = f"{host} (unit {unit_id})"
 
-            return self.async_update_reload_and_abort(
+            # Update the entry and let the existing update listener perform the
+            # single reload. We deliberately do not use a reloading config-flow
+            # helper here: combining it with the update listener is deprecated
+            # (HA 2026.6, error from 2026.12) because it reloads twice.
+            self.hass.config_entries.async_update_entry(
                 entry,
                 data=new_data,
                 title=title,
                 unique_id=new_unique_id,
             )
+            return self.async_abort(reason="reconfigure_successful")
 
         current = entry.data
         data_schema = vol.Schema(
@@ -274,7 +279,10 @@ class WebastoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 new_options[CONF_REST_ENABLED] = True
                 new_options[CONF_REST_USERNAME] = username
                 new_options[CONF_REST_PASSWORD] = password
-                return self.async_update_reload_and_abort(entry, options=new_options)
+                # The update listener performs the single reload (see the note
+                # in async_step_reconfigure).
+                self.hass.config_entries.async_update_entry(entry, options=new_options)
+                return self.async_abort(reason="reauth_successful")
 
         data_schema = vol.Schema(
             {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -161,7 +161,7 @@ async def test_reconfigure_shows_form() -> None:
 
 
 async def test_reconfigure_updates_connection() -> None:
-    """Reconfigure updates host/port/unit_id and reloads (validation via reload)."""
+    """Reconfigure updates host/port/unit_id; the update listener does the reload."""
 
     entry = MockConfigEntry(
         domain="webasto_next_modbus",
@@ -179,14 +179,9 @@ async def test_reconfigure_updates_connection() -> None:
     flow = WebastoConfigFlow()
     flow.hass = MagicMock()
 
-    sentinel = {"type": FlowResultType.ABORT, "reason": "reconfigure_successful"}
-
     with (
         patch.object(WebastoConfigFlow, "_get_reconfigure_entry", return_value=entry),
         patch.object(WebastoConfigFlow, "_async_current_entries", return_value=[entry]),
-        patch.object(
-            WebastoConfigFlow, "async_update_reload_and_abort", return_value=sentinel
-        ) as reload_abort,
     ):
         result = await flow.async_step_reconfigure(
             {
@@ -196,14 +191,16 @@ async def test_reconfigure_updates_connection() -> None:
             }
         )
 
-    reload_abort.assert_called_once()
-    _, kwargs = reload_abort.call_args
+    update = flow.hass.config_entries.async_update_entry
+    update.assert_called_once()
+    _, kwargs = update.call_args
     assert kwargs["data"][CONF_HOST] == "192.0.2.99"
     assert kwargs["data"][CONF_PORT] == 1502
     assert kwargs["data"][CONF_UNIT_ID] == 10
     assert kwargs["unique_id"] == "192.0.2.99-10"
     assert kwargs["title"] == "192.0.2.99 (unit 10)"
-    assert result is sentinel
+    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("reason") == "reconfigure_successful"
 
 
 async def test_reconfigure_aborts_on_identity_collision() -> None:
@@ -331,26 +328,23 @@ async def test_reauth_updates_credentials() -> None:
     flow = WebastoConfigFlow()
     flow.hass = MagicMock()
 
-    sentinel = {"type": FlowResultType.ABORT, "reason": "reauth_successful"}
-
     with (
         patch.object(WebastoConfigFlow, "_get_reauth_entry", return_value=entry),
         patch.object(WebastoConfigFlow, "_async_validate_rest", AsyncMock()) as validate,
-        patch.object(
-            WebastoConfigFlow, "async_update_reload_and_abort", return_value=sentinel
-        ) as reload_abort,
     ):
         result = await flow.async_step_reauth_confirm(
             {CONF_REST_USERNAME: "admin", CONF_REST_PASSWORD: "newpass"}
         )
 
     validate.assert_awaited_once()
-    reload_abort.assert_called_once()
-    _, kwargs = reload_abort.call_args
+    update = flow.hass.config_entries.async_update_entry
+    update.assert_called_once()
+    _, kwargs = update.call_args
     assert kwargs["options"][CONF_REST_USERNAME] == "admin"
     assert kwargs["options"][CONF_REST_PASSWORD] == "newpass"
     assert kwargs["options"][CONF_REST_ENABLED] is True
-    assert result is sentinel
+    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("reason") == "reauth_successful"
 
 
 async def test_reauth_invalid_auth() -> None:


### PR DESCRIPTION
## Summary

Forward-compatibility fix prompted by the HA developers blog post of **2026-05-07**, *"Deprecating config entry listener with reloading methods in config flow"* (deprecated in **2026.6**, error from **2026.12**).

The integration already reloads on entry update via an **update listener** (`add_update_listener` → `async_reload`), which the **options flow** relies on. The reconfigure (#67) and reauth (#68) flows additionally called `async_update_reload_and_abort`, which reloads **again** — the exact listener + reloading-method combination the blog deprecates (double reload / possible race).

**Fix:** switch both flows to `async_update_entry` + `async_abort`, so the update listener is the **single** reload mechanism — identical to how the existing options flow already behaves. Uses only long-stable APIs, so it works on the pinned `2026.5.1` **and** on `2026.6+` (rather than `async_update_and_abort`, which may not exist in 2026.5.1).

Tests updated to assert `async_update_entry` is called and the flow aborts with `reconfigure_successful` / `reauth_successful`.

## Test plan

- [x] No `async_update_reload_and_abort` left in the integration
- [x] ruff check + format + vulture clean (run locally)
- [ ] CI green on 3.14.2 / 2026.5.x

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_