### PR TITLE
feat(binary_sensor): add a Charging binary sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Credentials are stored in the Home Assistant config entry and redacted from down
 | Sensors | Charge point state, charging state, EVSE state, cable state, fault code, per-phase current and power, total energy, session energy and times, EV current limits, smart-vehicle detection. |
 | Numbers | Charging current limit (0–32 A), fail-safe current (6–32 A), fail-safe timeout (6–120 s). |
 | Buttons | Start charging, Stop charging, Send keep-alive. |
-| Binary sensors | Connected (`device_class: connectivity`). |
+| Binary sensors | Connected (`device_class: connectivity`), Charging (`device_class: battery_charging`). |
 
 ### REST API (when enabled)
 

--- a/custom_components/webasto_next_modbus/binary_sensor.py
+++ b/custom_components/webasto_next_modbus/binary_sensor.py
@@ -22,17 +22,15 @@ async def async_setup_entry(
     entry: WebastoConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the connectivity binary sensor."""
+    """Set up the connectivity and charging binary sensors."""
 
     runtime = entry.runtime_data
+    host = entry.data[CONF_HOST]
+    unit_id = entry.data[CONF_UNIT_ID]
     async_add_entities(
         [
-            WebastoConnectivitySensor(
-                runtime.coordinator,
-                entry.data[CONF_HOST],
-                entry.data[CONF_UNIT_ID],
-                runtime.device_name,
-            )
+            WebastoConnectivitySensor(runtime.coordinator, host, unit_id, runtime.device_name),
+            WebastoChargingSensor(runtime.coordinator, host, unit_id, runtime.device_name),
         ]
     )
 
@@ -71,6 +69,49 @@ class WebastoConnectivitySensor(  # type: ignore[misc]
     @property
     def is_on(self) -> bool:
         return self.coordinator.last_update_success
+
+    def _handle_coordinator_update(self) -> None:
+        self._attr_device_info = build_device_info(
+            self._unique_prefix, self._device_name, self.coordinator
+        )
+        super()._handle_coordinator_update()
+
+
+class WebastoChargingSensor(  # type: ignore[misc]
+    CoordinatorEntity[WebastoDataCoordinator], BinarySensorEntity
+):
+    """On while the wallbox is actively charging a vehicle."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
+    _attr_translation_key = "charging"
+
+    def __init__(
+        self,
+        coordinator: WebastoDataCoordinator,
+        host: str,
+        unit_id: int,
+        device_name: str,
+    ) -> None:
+        super().__init__(coordinator)
+        prefix = build_device_slug(host, unit_id)
+        self._unique_prefix = prefix
+        self._device_name = device_name
+        self._attr_unique_id = f"{prefix}-charging"
+        self._attr_device_info = build_device_info(prefix, device_name, coordinator)
+
+    @property
+    def is_on(self) -> bool | None:
+        data = self.coordinator.data
+        if not isinstance(data, dict):
+            return None
+        value = data.get("charging_state")
+        if value is None:
+            return None
+        try:
+            return int(value) == 1
+        except TypeError, ValueError:
+            return None
 
     def _handle_coordinator_update(self) -> None:
         self._attr_device_info = build_device_info(

--- a/custom_components/webasto_next_modbus/translations/de.json
+++ b/custom_components/webasto_next_modbus/translations/de.json
@@ -51,6 +51,9 @@
     "binary_sensor": {
       "connected": {
         "name": "Verbunden"
+      },
+      "charging": {
+        "name": "Lädt"
       }
     },
     "sensor": {

--- a/custom_components/webasto_next_modbus/translations/en.json
+++ b/custom_components/webasto_next_modbus/translations/en.json
@@ -81,6 +81,9 @@
     "binary_sensor": {
       "connected": {
         "name": "Connected"
+      },
+      "charging": {
+        "name": "Charging"
       }
     },
     "sensor": {

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.webasto_next_modbus.binary_sensor import WebastoChargingSensor
 from custom_components.webasto_next_modbus.button import WebastoButton
 from custom_components.webasto_next_modbus.const import (
     KEEPALIVE_TRIGGER_VALUE,
@@ -77,6 +78,25 @@ async def test_sensor_maps_enum_value(coordinator_fixture) -> None:
 
     assert sensor.unique_id == "192.0.2.10-7-charge_point_state"
     assert sensor.native_value == "charging"
+
+
+async def test_charging_binary_sensor_reflects_state(coordinator_fixture) -> None:
+    """The charging binary sensor is on only while charging_state == 1."""
+
+    coordinator, _bridge = coordinator_fixture
+    sensor = WebastoChargingSensor(coordinator, "192.0.2.10", 7, DEVICE_NAME)
+
+    assert sensor.unique_id == "192.0.2.10-7-charging"
+    assert sensor.translation_key == "charging"
+
+    coordinator.data = {"charging_state": 1}
+    assert sensor.is_on is True
+
+    coordinator.data = {"charging_state": 0}
+    assert sensor.is_on is False
+
+    coordinator.data = {}
+    assert sensor.is_on is None
 
 
 async def test_entity_has_correct_translation_attributes(coordinator_fixture) -> None:


### PR DESCRIPTION
## Summary (Tier 2, part 1)

Adds an on/off **"Charging"** binary sensor (`device_class: battery_charging`), driven by `charging_state`, alongside the existing **Connected** sensor.

This gives users a simple entity for dashboards and **state-based automations/conditions** without mapping the numeric `charging_state` themselves — and largely covers the "is_charging device condition" use case via a normal state condition.

- `is_on` follows `charging_state == 1`; returns `None` (unavailable) when the value is missing.
- Normal coordinator availability (goes unavailable when the wallbox is unreachable), unlike the always-available Connected sensor.
- en/de translations, a unit test, README entity-table update.

## Test plan

- [x] ruff/format/yamllint/codespell/vulture clean (run locally)
- [x] unit test asserts on/off/None mapping + unique_id + translation_key
- [ ] CI green on 3.14.2

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_