### PR TITLE
refactor(rest): use HA shared aiohttp session (inject-websession)

### DIFF
--- a/custom_components/webasto_next_modbus/config_flow.py
+++ b/custom_components/webasto_next_modbus/config_flow.py
@@ -305,9 +305,12 @@ class WebastoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def _async_validate_rest(self, host: str, username: str, password: str) -> None:
         """Open a REST session to confirm the credentials, then close it."""
 
+        from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
         from .rest_client import RestClient
 
-        client = RestClient(host, username, password)
+        session = async_get_clientsession(self.hass, verify_ssl=False)
+        client = RestClient(host, username, password, session)
         try:
             await client.connect()
         finally:
@@ -508,9 +511,12 @@ class WebastoOptionsFlow(config_entries.OptionsFlow):
 
     async def _validate_rest_connection(self, host: str, username: str, password: str) -> None:
         """Validate REST API connection."""
+        from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
         from .rest_client import RestClient, RestClientError
 
-        client = RestClient(host, username, password)
+        session = async_get_clientsession(self.hass, verify_ssl=False)
+        client = RestClient(host, username, password, session)
         try:
             if not await client.test_connection():
                 msg = "REST API connection test failed"

--- a/custom_components/webasto_next_modbus/config_flow.py
+++ b/custom_components/webasto_next_modbus/config_flow.py
@@ -303,7 +303,11 @@ class WebastoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def _async_validate_rest(self, host: str, username: str, password: str) -> None:
-        """Open a REST session to confirm the credentials, then close it."""
+        """Confirm the REST credentials by authenticating against the wallbox.
+
+        Uses Home Assistant's shared aiohttp session; ``disconnect()`` only
+        clears the token and never closes that session.
+        """
 
         from homeassistant.helpers.aiohttp_client import async_get_clientsession
 

--- a/custom_components/webasto_next_modbus/coordinator.py
+++ b/custom_components/webasto_next_modbus/coordinator.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.components import persistent_notification
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -102,7 +103,10 @@ class WebastoDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         from .rest_client import AuthenticationError, RestClient
 
         host = self._bridge.endpoint.split(":")[0]
-        self._rest_client = RestClient(host, username, password)
+        # Use Home Assistant's shared aiohttp session. The wallbox has a
+        # self-signed certificate, so SSL verification must be disabled.
+        session = async_get_clientsession(self.hass, verify_ssl=False)
+        self._rest_client = RestClient(host, username, password, session)
 
         try:
             await self._rest_client.connect()

--- a/custom_components/webasto_next_modbus/rest_client.py
+++ b/custom_components/webasto_next_modbus/rest_client.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
-import ssl
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Final
@@ -96,6 +94,7 @@ class RestClient:
         host: str,
         username: str,
         password: str,
+        session: aiohttp.ClientSession,
         *,
         timeout: int = DEFAULT_TIMEOUT,
     ) -> None:
@@ -105,18 +104,22 @@ class RestClient:
             host: Wallbox IP address or hostname.
             username: Web interface username (usually "admin").
             password: Web interface password.
+            session: Shared aiohttp session (from
+                ``async_get_clientsession(hass, verify_ssl=False)``). The
+                wallbox uses a self-signed certificate, hence ``verify_ssl``
+                must be disabled by the caller. The session is owned by Home
+                Assistant and must not be closed here.
             timeout: Request timeout in seconds.
         """
         self._host = host
         self._username = username
         self._password = password
-        self._timeout = timeout
         self._base_url = f"https://{host}/api"
 
-        self._session: aiohttp.ClientSession | None = None
+        self._session = session
+        self._request_timeout = aiohttp.ClientTimeout(total=timeout)
         self._token: str | None = None
         self._token_expires: datetime | None = None
-        self._ssl_context: ssl.SSLContext | None = None
 
     @property
     def is_connected(self) -> bool:
@@ -126,34 +129,20 @@ class RestClient:
         return datetime.now(UTC) < self._token_expires - TOKEN_REFRESH_MARGIN
 
     async def connect(self) -> None:
-        """Establish connection and authenticate.
-
-        On failure the session is closed again so callers can simply discard
-        the client without leaking an open aiohttp session.
+        """Authenticate against the wallbox REST API.
 
         Raises:
             AuthenticationError: If login fails.
             ConnectionError: If connection to wallbox fails.
         """
-        await self._ensure_session()
-        login_ok = False
-        try:
-            await self._login()
-            login_ok = True
-        finally:
-            if not login_ok:
-                # Covers exceptions *and* task cancellation (HA shutdown).
-                # Shield the close so it still runs to completion even if a
-                # cancellation interrupts us here, instead of leaving an open
-                # aiohttp session behind.
-                with contextlib.suppress(Exception):
-                    await asyncio.shield(self.disconnect())
+        await self._login()
 
     async def disconnect(self) -> None:
-        """Close the session."""
-        if self._session is not None:
-            await self._session.close()
-            self._session = None
+        """Forget the auth token.
+
+        The aiohttp session is owned by Home Assistant (shared), so it is
+        intentionally not closed here.
+        """
         self._token = None
         self._token_expires = None
 
@@ -286,25 +275,6 @@ class RestClient:
     # Private methods
     # -------------------------------------------------------------------------
 
-    async def _ensure_session(self) -> None:
-        """Create the aiohttp session if it doesn't exist yet."""
-        if self._session is not None and not self._session.closed:
-            return
-
-        if self._ssl_context is None:
-            # A bare TLS-client context, not ssl.create_default_context():
-            # the latter calls load_default_certs(), which does blocking file
-            # I/O and trips Home Assistant's blocking-call detector. The wallbox
-            # uses a self-signed certificate, so verification is disabled anyway.
-            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-            ctx.check_hostname = False
-            ctx.verify_mode = ssl.CERT_NONE
-            self._ssl_context = ctx
-
-        connector = aiohttp.TCPConnector(ssl=self._ssl_context)
-        timeout = aiohttp.ClientTimeout(total=self._timeout)
-        self._session = aiohttp.ClientSession(connector=connector, timeout=timeout)
-
     async def _ensure_token(self) -> None:
         """Ensure we have a valid token, refresh if needed."""
         if not self.is_connected:
@@ -312,16 +282,11 @@ class RestClient:
 
     async def _login(self) -> None:
         """Authenticate and obtain JWT token."""
-        if self._session is None:
-            await self._ensure_session()
-
-        assert self._session is not None  # noqa: S101
-
         url = f"{self._base_url}/login"
         payload = {"username": self._username, "password": self._password}
 
         try:
-            async with self._session.post(url, json=payload) as resp:
+            async with self._session.post(url, json=payload, timeout=self._request_timeout) as resp:
                 if resp.status == 401:
                     msg = "Invalid username or password"
                     raise AuthenticationError(msg)
@@ -375,10 +340,8 @@ class RestClient:
         json: Mapping[str, Any] | list[dict[str, Any]] | None = None,
     ) -> Any:
         """Make authenticated request with retry logic."""
-        await self._ensure_session()
         await self._ensure_token()
 
-        assert self._session is not None  # noqa: S101
         assert self._token is not None  # noqa: S101
 
         url = f"{self._base_url}{path}"
@@ -390,10 +353,9 @@ class RestClient:
         last_error: Exception | None = None
         for attempt in range(1, MAX_RETRY_ATTEMPTS + 1):
             try:
-                await self._ensure_session()
-                assert self._session is not None  # noqa: S101
-
-                async with self._session.request(method, url, headers=headers, json=json) as resp:
+                async with self._session.request(
+                    method, url, headers=headers, json=json, timeout=self._request_timeout
+                ) as resp:
                     if resp.status == 401:
                         # Token expired, re-authenticate
                         _LOGGER.debug("Token expired (401), re-authenticating...")
@@ -422,11 +384,6 @@ class RestClient:
                     f"{method} {path}",
                     err,
                 )
-
-                # Force session close to ensure fresh connection on retry
-                if self._session and not self._session.closed:
-                    await self._session.close()
-                self._session = None
 
                 if attempt == MAX_RETRY_ATTEMPTS:
                     break

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -274,6 +274,7 @@ async def test_coordinator_rest_auth_failure_starts_reauth() -> None:
 
     with (
         patch.object(entry, "async_start_reauth") as start_reauth,
+        patch("custom_components.webasto_next_modbus.coordinator.async_get_clientsession"),
         patch("custom_components.webasto_next_modbus.rest_client.RestClient") as mock_rc,
     ):
         mock_rc.return_value.connect = AsyncMock(side_effect=AuthenticationError("bad creds"))
@@ -300,6 +301,7 @@ async def test_coordinator_rest_success_does_not_start_reauth() -> None:
 
     with (
         patch.object(entry, "async_start_reauth") as start_reauth,
+        patch("custom_components.webasto_next_modbus.coordinator.async_get_clientsession"),
         patch("custom_components.webasto_next_modbus.rest_client.RestClient") as mock_rc,
     ):
         mock_rc.return_value.connect = AsyncMock()


### PR DESCRIPTION
## Summary (Platinum: inject-websession)

The REST client created and **owned its own** `aiohttp.ClientSession` (custom no-verify SSL context + TCPConnector). This switches it to **Home Assistant's shared session** via `async_get_clientsession(hass, verify_ssl=False)`, injected into `RestClient`.

This satisfies the Platinum **`inject-websession`** quality-scale rule and is genuinely cleaner:
- No per-client session lifecycle (no "unclosed session" risk).
- Shared connection pooling across the integration.
- HA performs the SSL setup (non-blocking) for the wallbox's self-signed cert via `verify_ssl=False` — we drop our hand-rolled SSL context.

**Behavioural changes:**
- `connect()` only logs in; `disconnect()` only forgets the token (never closes the shared session).
- Per-request timeouts replace the session-wide timeout.
- Dropped the close-session-on-retry (can't close a shared session; aiohttp's pool handles reconnects).
- Coordinator + both config-flow REST validators obtain and inject the shared session.

## Test plan

- [x] ruff/format/vulture/bandit clean; no leftover own-session code (run locally)
- [x] coordinator REST tests patch `async_get_clientsession`
- [ ] CI green on 3.14.2 (mypy is the key check — `_session` is now non-optional, types tighten)

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_