### PR TITLE
chore: add py.typed marker (typed package)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ packages = [
   "virtual_wallbox",
 ]
 
+[tool.setuptools.package-data]
+"custom_components.webasto_next_modbus" = ["py.typed"]
+
 [build-system]
 requires = ["setuptools>=68"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary

Adds the **`py.typed`** marker (PEP 561) so type checkers honour the integration's annotations, shipped via `package-data`.

This is the **marker half** of the Platinum `strict-typing` quality-scale rule. The integration currently runs mypy in default mode (there is no `[tool.mypy]` config); enabling **strict mypy** and fixing any findings is a deliberate follow-up — it can't be pre-verified locally (no Python 3.14.2 / HA here), so it would be CI-iterative.

## Test plan

- [x] `py.typed` tracked + declared in `package-data`; pyproject still valid TOML
- [ ] CI green on 3.14.2

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_