### PR TITLE
ci: enable strict mypy (Platinum strict-typing)

### DIFF
--- a/custom_components/webasto_next_modbus/__init__.py
+++ b/custom_components/webasto_next_modbus/__init__.py
@@ -7,6 +7,7 @@ import logging
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
+from typing import cast
 
 import voluptuous as vol
 from homeassistant.components import persistent_notification
@@ -371,13 +372,13 @@ def _resolve_runtime(hass: HomeAssistant, call: ServiceCall) -> RuntimeData:
         raise ValueError("Webasto Next Modbus is not configured")
 
     if len(entries) == 1:
-        return entries[0].runtime_data
+        return cast(RuntimeData, entries[0].runtime_data)
 
     entry_id = call.data.get("config_entry_id")
     if entry_id:
         for entry in entries:
             if entry.entry_id == entry_id:
-                return entry.runtime_data
+                return cast(RuntimeData, entry.runtime_data)
 
     raise ValueError("Multiple wallboxes configured – set config_entry_id in the service call")
 

--- a/custom_components/webasto_next_modbus/binary_sensor.py
+++ b/custom_components/webasto_next_modbus/binary_sensor.py
@@ -35,9 +35,7 @@ async def async_setup_entry(
     )
 
 
-class WebastoConnectivitySensor(  # type: ignore[misc]
-    CoordinatorEntity[WebastoDataCoordinator], BinarySensorEntity
-):
+class WebastoConnectivitySensor(CoordinatorEntity[WebastoDataCoordinator], BinarySensorEntity):
     """Reports whether the integration is currently reaching the wallbox."""
 
     _attr_has_entity_name = True
@@ -77,9 +75,7 @@ class WebastoConnectivitySensor(  # type: ignore[misc]
         super()._handle_coordinator_update()
 
 
-class WebastoChargingSensor(  # type: ignore[misc]
-    CoordinatorEntity[WebastoDataCoordinator], BinarySensorEntity
-):
+class WebastoChargingSensor(CoordinatorEntity[WebastoDataCoordinator], BinarySensorEntity):
     """On while the wallbox is actively charging a vehicle."""
 
     _attr_has_entity_name = True

--- a/custom_components/webasto_next_modbus/button.py
+++ b/custom_components/webasto_next_modbus/button.py
@@ -59,7 +59,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class WebastoButton(WebastoRegisterEntity, ButtonEntity):  # type: ignore[misc]
+class WebastoButton(WebastoRegisterEntity, ButtonEntity):
     """Represent write-only Modbus actions as buttons."""
 
     _attr_has_entity_name = True
@@ -86,7 +86,7 @@ class WebastoButton(WebastoRegisterEntity, ButtonEntity):  # type: ignore[misc]
         await self.coordinator.async_request_refresh()
 
 
-class WebastoRestartButton(WebastoRestEntity, ButtonEntity):  # type: ignore[misc]
+class WebastoRestartButton(WebastoRestEntity, ButtonEntity):
     """Button to restart the wallbox via REST API."""
 
     _attr_has_entity_name = True

--- a/custom_components/webasto_next_modbus/diagnostics.py
+++ b/custom_components/webasto_next_modbus/diagnostics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -14,7 +15,7 @@ from .const import CONF_REST_PASSWORD, CONF_REST_USERNAME
 TO_REDACT = {CONF_HOST, CONF_REST_PASSWORD, CONF_REST_USERNAME}
 
 
-def _iso_or_none(value):
+def _iso_or_none(value: datetime | None) -> str | None:
     return value.isoformat() if value else None
 
 

--- a/custom_components/webasto_next_modbus/hub.py
+++ b/custom_components/webasto_next_modbus/hub.py
@@ -516,18 +516,18 @@ class ModbusBridge:
                         register.address,
                         count=register.count,
                     )
-            except (modbus_exception, OSError, ConnectionError) as err:  # type: ignore[misc]
+            except (modbus_exception, OSError, ConnectionError) as err:
                 # Mark client as disconnected to force reconnect on next attempt
                 self._client = None
                 raise WebastoModbusError(str(err)) from err
 
-        if not hasattr(response, "isError") or response.isError():  # type: ignore[attr-defined]
+        if not hasattr(response, "isError") or response.isError():
             raise WebastoModbusDeviceError(
                 f"reading {register.key} (@{register.address}) failed: "
                 f"{_describe_modbus_response(response)}"
             )
 
-        return _decode_register(register, response.registers)  # type: ignore[attr-defined]
+        return _decode_register(register, response.registers)
 
     async def _async_read_data_once(self) -> dict[str, float | int | str | None]:
         data: dict[str, float | int | str | None] = {}
@@ -552,12 +552,12 @@ class ModbusBridge:
                             request.start_address,
                             count=request.count,
                         )
-                except (modbus_exception, OSError, ConnectionError) as err:  # type: ignore[misc]
+                except (modbus_exception, OSError, ConnectionError) as err:
                     # Mark client as disconnected to force reconnect on next attempt
                     self._client = None
                     raise WebastoModbusError(str(err)) from err
 
-                if response.isError():  # type: ignore[attr-defined]
+                if response.isError():
                     detail = _describe_modbus_response(response)
                     if not read_any:
                         # The first (core) block came back as an error: the
@@ -592,7 +592,7 @@ class ModbusBridge:
                     continue
 
                 read_any = True
-                registers = response.registers  # type: ignore[attr-defined]
+                registers = response.registers
                 for definition in request.registers:
                     offset = definition.address - request.start_address
                     slice_end = offset + definition.count
@@ -622,12 +622,12 @@ class ModbusBridge:
                     register.address,
                     value,
                 )
-            except (modbus_exception, OSError, ConnectionError) as err:  # type: ignore[misc]
+            except (modbus_exception, OSError, ConnectionError) as err:
                 # Mark client as disconnected to force reconnect on next attempt
                 self._client = None
                 raise WebastoModbusError(str(err)) from err
 
-        if response.isError():  # type: ignore[attr-defined]
+        if response.isError():
             raise WebastoModbusDeviceError(
                 f"writing {register.key} (@{register.address}) failed: "
                 f"{_describe_modbus_response(response)}"

--- a/custom_components/webasto_next_modbus/number.py
+++ b/custom_components/webasto_next_modbus/number.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from homeassistant.components.number import NumberEntity, NumberMode, RestoreNumber
+from homeassistant.components.number import (
+    NumberEntity,
+    NumberExtraStoredData,
+    NumberMode,
+    RestoreNumber,
+)
 from homeassistant.const import CONF_HOST, PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -13,10 +18,15 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import WebastoConfigEntry
-from .const import CONF_UNIT_ID, SIGNAL_REGISTER_WRITTEN, get_number_registers
+from .const import (
+    CONF_UNIT_ID,
+    SIGNAL_REGISTER_WRITTEN,
+    RegisterDefinition,
+    get_number_registers,
+)
 from .coordinator import WebastoDataCoordinator
 from .entity import WebastoRegisterEntity, WebastoRestEntity
-from .hub import WebastoModbusError
+from .hub import ModbusBridge, WebastoModbusError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,7 +71,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class WebastoNumber(WebastoRegisterEntity, RestoreNumber, NumberEntity):  # type: ignore[misc]
+class WebastoNumber(WebastoRegisterEntity, RestoreNumber, NumberEntity):
     """Expose writable Modbus registers as number entities."""
 
     _attr_has_entity_name = True
@@ -69,11 +79,11 @@ class WebastoNumber(WebastoRegisterEntity, RestoreNumber, NumberEntity):  # type
 
     def __init__(
         self,
-        coordinator,
-        bridge,
+        coordinator: WebastoDataCoordinator,
+        bridge: ModbusBridge,
         host: str,
         unit_id: int,
-        register,
+        register: RegisterDefinition,
         device_name: str,
         variant_max_current: int | None = None,
     ) -> None:
@@ -185,7 +195,9 @@ class WebastoNumber(WebastoRegisterEntity, RestoreNumber, NumberEntity):  # type
         )
         self.async_on_remove(remove)
 
-    async def _async_init_write_only_value(self, last_number_data) -> None:
+    async def _async_init_write_only_value(
+        self, last_number_data: NumberExtraStoredData | None
+    ) -> None:
         """Seed the value from the wallbox, or re-assert the restored value."""
 
         if await self._async_seed_from_wallbox():
@@ -255,7 +267,7 @@ class WebastoNumber(WebastoRegisterEntity, RestoreNumber, NumberEntity):  # type
             self.async_write_ha_state()
 
 
-class WebastoLedBrightness(WebastoRestEntity, NumberEntity):  # type: ignore[misc]
+class WebastoLedBrightness(WebastoRestEntity, NumberEntity):
     """Number entity for LED brightness via REST API."""
 
     _attr_has_entity_name = True

--- a/custom_components/webasto_next_modbus/rest_client.py
+++ b/custom_components/webasto_next_modbus/rest_client.py
@@ -548,7 +548,7 @@ class RestClient:
         import re
 
         pattern = r"inet\s+(\d+\.\d+\.\d+\.\d+)"
-        matches = re.findall(pattern, interfaces_str)
+        matches: list[str] = re.findall(pattern, interfaces_str)
 
         for ip in matches:
             if not ip.startswith("127.") and not ip.startswith("172.20."):

--- a/custom_components/webasto_next_modbus/sensor.py
+++ b/custom_components/webasto_next_modbus/sensor.py
@@ -12,9 +12,10 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from . import WebastoConfigEntry
-from .const import CONF_UNIT_ID, get_sensor_registers
+from .const import CONF_UNIT_ID, RegisterDefinition, get_sensor_registers
 from .coordinator import WebastoDataCoordinator
 from .entity import WebastoRegisterEntity, WebastoRestEntity
+from .hub import ModbusBridge
 from .rest_client import RestData
 
 
@@ -129,18 +130,18 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class WebastoSensor(WebastoRegisterEntity, SensorEntity):  # type: ignore[misc]
+class WebastoSensor(WebastoRegisterEntity, SensorEntity):
     """Representation of a Webasto Modbus register as a sensor."""
 
     _attr_has_entity_name = True
 
     def __init__(
         self,
-        coordinator,
-        bridge,
+        coordinator: WebastoDataCoordinator,
+        bridge: ModbusBridge,
         host: str,
         unit_id: int,
-        register,
+        register: RegisterDefinition,
         device_name: str,
     ) -> None:
         super().__init__(coordinator, bridge, host, unit_id, register, device_name)
@@ -200,7 +201,7 @@ class WebastoSensor(WebastoRegisterEntity, SensorEntity):  # type: ignore[misc]
             self._attr_native_value = value
 
 
-class WebastoRestSensor(WebastoRestEntity, SensorEntity):  # type: ignore[misc]
+class WebastoRestSensor(WebastoRestEntity, SensorEntity):
     """Sensor entity for REST API data."""
 
     _attr_has_entity_name = True

--- a/custom_components/webasto_next_modbus/switch.py
+++ b/custom_components/webasto_next_modbus/switch.py
@@ -9,9 +9,10 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import WebastoConfigEntry
-from .const import CONF_UNIT_ID, get_switch_registers
+from .const import CONF_UNIT_ID, RegisterDefinition, get_switch_registers
 from .coordinator import WebastoDataCoordinator
 from .entity import WebastoRegisterEntity, WebastoRestEntity
+from .hub import ModbusBridge
 
 
 async def async_setup_entry(
@@ -51,7 +52,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class WebastoPhaseSwitch(WebastoRegisterEntity, SwitchEntity):  # type: ignore[misc]
+class WebastoPhaseSwitch(WebastoRegisterEntity, SwitchEntity):
     """Switch the wallbox between single- and three-phase charging via Modbus.
 
     Writes the phase-switch holding register (1 = three-phase, 0 = single-phase)
@@ -69,10 +70,10 @@ class WebastoPhaseSwitch(WebastoRegisterEntity, SwitchEntity):  # type: ignore[m
     def __init__(
         self,
         coordinator: WebastoDataCoordinator,
-        bridge,
+        bridge: ModbusBridge,
         host: str,
         unit_id: int,
-        register,
+        register: RegisterDefinition,
         device_name: str,
     ) -> None:
         super().__init__(coordinator, bridge, host, unit_id, register, device_name)
@@ -115,7 +116,7 @@ class WebastoPhaseSwitch(WebastoRegisterEntity, SwitchEntity):  # type: ignore[m
         await self.coordinator.async_request_refresh()
 
 
-class WebastoFreeChargingSwitch(WebastoRestEntity, SwitchEntity):  # type: ignore[misc]
+class WebastoFreeChargingSwitch(WebastoRestEntity, SwitchEntity):
     """Switch entity for Free Charging mode via REST API."""
 
     _attr_has_entity_name = True

--- a/custom_components/webasto_next_modbus/text.py
+++ b/custom_components/webasto_next_modbus/text.py
@@ -58,7 +58,7 @@ def _migrate_tag_id_unique_id(hass: HomeAssistant, host: str, unit_id: int) -> N
         registry.async_update_entity(old_entity_id, new_unique_id=new_uid)
 
 
-class WebastoFreeChargingTagIdText(WebastoRestEntity, TextEntity):  # type: ignore[misc]
+class WebastoFreeChargingTagIdText(WebastoRestEntity, TextEntity):
     """Text entity for Free Charging Tag ID via REST API."""
 
     _attr_has_entity_name = True
@@ -76,7 +76,7 @@ class WebastoFreeChargingTagIdText(WebastoRestEntity, TextEntity):  # type: igno
         super().__init__(coordinator, host, unit_id, _TAG_ID_KEY, device_name)
 
     @property
-    def native_value(self) -> str | None:  # type: ignore[override]
+    def native_value(self) -> str | None:
         """Return the current value."""
         if not self.coordinator.rest_data:
             return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,17 @@ packages = [
 [tool.setuptools.package-data]
 "custom_components.webasto_next_modbus" = ["py.typed"]
 
+[tool.mypy]
+strict = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+
+[[tool.mypy.overrides]]
+# voluptuous ships no type information; treat it as untyped rather than
+# erroring on the missing stubs.
+module = ["voluptuous", "voluptuous.*"]
+ignore_missing_imports = true
+
 [build-system]
 requires = ["setuptools>=68"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary (Platinum: strict-typing)

Enables **strict mypy** on the integration via a `[tool.mypy]` config (`strict = true`), the strict-typing half that pairs with the `py.typed` marker (#72). `voluptuous` (ships no type information) is treated as untyped via an override.

This is the discovery run — strict mypy may surface typing gaps the default mode didn't. Any findings will be fixed in follow-up commits on this PR.

## Test plan

- [x] pyproject valid TOML
- [ ] CI `build` (mypy strict) green on 3.14.2 — **the key check; expect to iterate**

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_