### PR TITLE
feat: add quality_scale.yaml + close parallel-updates/action-setup

### DIFF
--- a/.vulture_whitelist.py
+++ b/.vulture_whitelist.py
@@ -1,4 +1,6 @@
 # .vulture_whitelist.py
+async_setup  # unused function
+config  # unused arg required by Home Assistant's async_setup signature
 async_setup_entry  # unused function
 async_unload_entry  # unused function
 async_press  # unused function

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ To test upcoming changes, enable **Show beta versions** on the integration in HA
 1. Copy `custom_components/webasto_next_modbus/` from this repository into your Home Assistant `config/custom_components/` directory.
 2. Restart Home Assistant.
 
+### Removal
+
+1. Go to **Settings → Devices & Services → Webasto Next / Unite**, open the **⋮** menu on the entry and choose **Delete**. This removes the device, its entities and stored credentials.
+2. If you installed via HACS, optionally remove the repository from HACS; for a manual install, delete `custom_components/webasto_next_modbus/`. Restart Home Assistant.
+
 ## Configuration
 
 ### Before you start: enable Modbus on the wallbox

--- a/custom_components/webasto_next_modbus/__init__.py
+++ b/custom_components/webasto_next_modbus/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     CONF_MODEL,
@@ -87,6 +88,18 @@ class RuntimeData:
 
 
 type WebastoConfigEntry = ConfigEntry[RuntimeData]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Register integration-wide service actions.
+
+    Done here (not in async_setup_entry) so the actions exist and validate even
+    before a config entry is set up, and persist for the lifetime of Home
+    Assistant regardless of entry reloads.
+    """
+
+    _register_services(hass)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: WebastoConfigEntry) -> bool:
@@ -198,8 +211,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: WebastoConfigEntry) -> b
 
     entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
 
-    _register_services(hass)
-
     return True
 
 
@@ -229,19 +240,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: WebastoConfigEntry) -> 
         await runtime.bridge.async_close()
         _LOGGER.debug("Connection closed for entry %s", entry.entry_id)
 
-    if not _has_other_loaded_entries(hass, entry):
-        _unregister_services(hass)
-
     _LOGGER.info("Config entry %s unloaded successfully", entry.entry_id)
     return unload_ok
-
-
-def _has_other_loaded_entries(hass: HomeAssistant, current: WebastoConfigEntry) -> bool:
-    """Return True if any other loaded config entry still exists."""
-    return any(
-        entry.entry_id != current.entry_id
-        for entry in hass.config_entries.async_loaded_entries(DOMAIN)
-    )
 
 
 async def _async_reload_entry(hass: HomeAssistant, entry: WebastoConfigEntry) -> None:
@@ -336,24 +336,6 @@ def _register_services(hass: HomeAssistant) -> None:
     )
 
     _SERVICES_REGISTERED = True
-
-
-def _unregister_services(hass: HomeAssistant) -> None:
-    """Remove integration services when no entries remain."""
-
-    global _SERVICES_REGISTERED
-    if not _SERVICES_REGISTERED:
-        return
-
-    hass.services.async_remove(DOMAIN, SERVICE_SET_CURRENT)
-    hass.services.async_remove(DOMAIN, SERVICE_SET_FAILSAFE)
-    hass.services.async_remove(DOMAIN, SERVICE_SEND_KEEPALIVE)
-    hass.services.async_remove(DOMAIN, SERVICE_START_SESSION)
-    hass.services.async_remove(DOMAIN, SERVICE_STOP_SESSION)
-    hass.services.async_remove(DOMAIN, SERVICE_SET_LED_BRIGHTNESS)
-    hass.services.async_remove(DOMAIN, SERVICE_SET_FREE_CHARGING)
-    hass.services.async_remove(DOMAIN, SERVICE_RESTART_WALLBOX)
-    _SERVICES_REGISTERED = False
 
 
 def _resolve_runtime(hass: HomeAssistant, call: ServiceCall) -> RuntimeData:

--- a/custom_components/webasto_next_modbus/binary_sensor.py
+++ b/custom_components/webasto_next_modbus/binary_sensor.py
@@ -16,6 +16,8 @@ from .const import CONF_UNIT_ID, build_device_slug
 from .coordinator import WebastoDataCoordinator
 from .entity import build_device_info
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/webasto_next_modbus/button.py
+++ b/custom_components/webasto_next_modbus/button.py
@@ -20,6 +20,8 @@ from .coordinator import WebastoDataCoordinator
 from .device_trigger import TRIGGER_KEEPALIVE_SENT, async_fire_device_trigger
 from .entity import WebastoRegisterEntity, WebastoRestEntity
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/webasto_next_modbus/number.py
+++ b/custom_components/webasto_next_modbus/number.py
@@ -31,6 +31,9 @@ from .hub import ModbusBridge, WebastoModbusError
 _LOGGER = logging.getLogger(__name__)
 
 
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: WebastoConfigEntry,

--- a/custom_components/webasto_next_modbus/quality_scale.yaml
+++ b/custom_components/webasto_next_modbus/quality_scale.yaml
@@ -1,0 +1,82 @@
+rules:
+  # Bronze
+  action-setup: done
+  appropriate-polling: done
+  brands:
+    status: exempt
+    comment: >-
+      Custom (HACS) integration; brand assets live with the HACS repository,
+      not in the Home Assistant brands repository.
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions: done
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions: done
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow: done
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: done
+  discovery:
+    status: exempt
+    comment: >-
+      Webasto Next / Unite wallboxes do not advertise a discoverable service;
+      they are configured manually by IP address.
+  discovery-update-info:
+    status: exempt
+    comment: No network discovery (see "discovery"), so there is nothing to update.
+  docs-data-update: done
+  docs-examples: done
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: done
+  dynamic-devices:
+    status: exempt
+    comment: >-
+      Each config entry represents exactly one wallbox (one device); there are
+      no dynamically added sub-devices.
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default:
+    status: exempt
+    comment: >-
+      All entities are low-cardinality and useful by default; none are noisy
+      enough to warrant being disabled.
+  entity-translations: done
+  exception-translations: todo
+  icon-translations: todo
+  reconfiguration-flow: done
+  repair-issues: todo
+  stale-devices:
+    status: exempt
+    comment: >-
+      One device per config entry, removed together with the entry; no stale
+      devices can accumulate.
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: done

--- a/custom_components/webasto_next_modbus/sensor.py
+++ b/custom_components/webasto_next_modbus/sensor.py
@@ -90,6 +90,9 @@ REST_SENSORS: list[RestSensorDefinition] = [
 ]
 
 
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: WebastoConfigEntry,

--- a/custom_components/webasto_next_modbus/switch.py
+++ b/custom_components/webasto_next_modbus/switch.py
@@ -14,6 +14,8 @@ from .coordinator import WebastoDataCoordinator
 from .entity import WebastoRegisterEntity, WebastoRestEntity
 from .hub import ModbusBridge
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/webasto_next_modbus/text.py
+++ b/custom_components/webasto_next_modbus/text.py
@@ -17,6 +17,9 @@ from .entity import WebastoRestEntity
 _TAG_ID_KEY = "free_charging_tag_id"
 
 
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: WebastoConfigEntry,


### PR DESCRIPTION
## Summary

Adds an honest **`quality_scale.yaml`** auditing all 52 rules, and closes the two real Bronze/Silver gaps it surfaced so the claims are true.

**Audit result:**
- **Bronze + Silver**: fully met (done / exempt) — consistent with the declared `silver`.
- **Platinum**: all three done (`async-dependency`, `inject-websession`, `strict-typing`).
- **Gold**: mostly done/exempt; **3 todos** remain: `exception-translations`, `icon-translations`, `repair-issues`.
- Exemptions (with comments): `brands` (custom/HACS), `discovery` + `discovery-update-info` (manual IP, no advertisement), `dynamic-devices` + `stale-devices` (one device per entry), `entity-disabled-by-default` (no noisy entities).

**Code changes to make Silver genuinely true:**
- `parallel-updates`: declare `PARALLEL_UPDATES = 0` on every entity platform (the coordinator already serialises updates).
- `action-setup`: register the service actions in **`async_setup`** instead of `async_setup_entry`, so they exist/validate before any entry and persist across reloads; dropped the entry-scoped (un)registration (and the now-unused helper).
- `docs-removal-instructions`: added a **Removal** section to the README.

Manifest stays at **`silver`** — it'll be bumped once the 3 Gold todos are closed (next: the `#36` "Modbus not enabled" repair issue, then icon/exception translations).

## Test plan

- [x] All 52 rule keys present and well-formed; yamllint + ruff + vulture clean (run locally)
- [ ] CI green on 3.14.2 (mypy on the `async_setup` refactor; hassfest on `quality_scale.yaml`)

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_