### PR TITLE
docs(quality-scale): mark repair-issues exempt

### DIFF
--- a/custom_components/webasto_next_modbus/quality_scale.yaml
+++ b/custom_components/webasto_next_modbus/quality_scale.yaml
@@ -69,7 +69,18 @@ rules:
   exception-translations: todo
   icon-translations: todo
   reconfiguration-flow: done
-  repair-issues: todo
+  repair-issues:
+    status: exempt
+    comment: >-
+      The integration has no reliably-detectable, user-fixable condition that
+      warrants a persistent repair issue. A failed/refused Modbus connection is
+      ambiguous and transient (wallbox booting, a stale socket, or the
+      single-connection slot held by another client) and is surfaced via
+      ConfigEntryNotReady with automatic retry; setup guidance (enable Modbus in
+      the wallbox expert view, check host/port) lives in the README and
+      troubleshooting docs. Rejected REST credentials are handled by the reauth
+      flow. Wallbox faults are exposed as the fault_code / active_errors
+      sensors, not as repairs.
   stale-devices:
     status: exempt
     comment: >-


### PR DESCRIPTION
## Summary

Marks `repair-issues` as **exempt** in the quality scale, with justification.

A failed/refused Modbus connection is **ambiguous and transient** — the wallbox booting, a stale socket, or the single Modbus-connection slot held by another client (e.g. EVCC) all surface as "connection refused", indistinguishable from "Modbus disabled". So it's handled via `ConfigEntryNotReady` + automatic retry rather than a false-positive-prone repair issue (which would re-appear on every reboot). Setup guidance (enable Modbus in the expert view, check host/port) lives in the README/troubleshooting; rejected REST credentials use the reauth flow; wallbox faults are exposed as the `fault_code` / `active_errors` sensors.

Leaves **two Gold todos**: `icon-translations` and `exception-translations`.

## Test plan

- [x] 52 rules intact, well-formed; yamllint clean
- [ ] CI green (hassfest)

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_