### PR TITLE
feat: move entity icons to icons.json (icon-translations)

### DIFF
--- a/custom_components/webasto_next_modbus/button.py
+++ b/custom_components/webasto_next_modbus/button.py
@@ -94,7 +94,6 @@ class WebastoRestartButton(WebastoRestEntity, ButtonEntity):
     _attr_has_entity_name = True
     _attr_device_class = ButtonDeviceClass.RESTART
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_icon = "mdi:restart"
 
     def __init__(
         self,

--- a/custom_components/webasto_next_modbus/const.py
+++ b/custom_components/webasto_next_modbus/const.py
@@ -101,7 +101,6 @@ class RegisterDefinition:
     unit: str | None = None
     device_class: str | None = None
     state_class: str | None = None
-    icon: str | None = None
     entity_category: str | None = None
     options: dict[int, str] | None = None
     writable: bool = False
@@ -199,7 +198,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         data_type="uint16",
         entity="sensor",
         device_class="enum",
-        icon="mdi:ev-station",
         options=CHARGE_POINT_STATE_MAP,
         translation_key="charge_point_state",
     ),
@@ -212,7 +210,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         data_type="uint16",
         entity="sensor",
         device_class="enum",
-        icon="mdi:battery-charging",
         options=CHARGING_STATE_MAP,
         translation_key="charging_state",
     ),
@@ -225,7 +222,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         data_type="uint16",
         entity="sensor",
         device_class="enum",
-        icon="mdi:cog-outline",
         options=EQUIPMENT_STATE_MAP,
         translation_key="equipment_state",
     ),
@@ -238,7 +234,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         data_type="uint16",
         entity="sensor",
         device_class="enum",
-        icon="mdi:cable-data",
         options=CABLE_STATE_MAP,
         translation_key="cable_state",
     ),
@@ -251,7 +246,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         data_type="uint16",
         entity="sensor",
         device_class="enum",
-        icon="mdi:alert",
         entity_category="diagnostic",
         options=FAULT_CODE_MAP,
         translation_key="fault_code",
@@ -268,7 +262,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         unit="A",
         device_class="current",
         state_class="measurement",
-        icon="mdi:current-ac",
         translation_key="current_l1_a",
     ),
     RegisterDefinition(
@@ -283,7 +276,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         unit="A",
         device_class="current",
         state_class="measurement",
-        icon="mdi:current-ac",
         translation_key="current_l2_a",
     ),
     RegisterDefinition(
@@ -298,7 +290,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         unit="A",
         device_class="current",
         state_class="measurement",
-        icon="mdi:current-ac",
         translation_key="current_l3_a",
     ),
     RegisterDefinition(
@@ -312,7 +303,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         unit="W",
         device_class="power",
         state_class="measurement",
-        icon="mdi:lightning-bolt",
         translation_key="active_power_total_w",
     ),
     RegisterDefinition(
@@ -326,7 +316,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         unit="W",
         device_class="power",
         state_class="measurement",
-        icon="mdi:lightning-bolt",
         translation_key="active_power_l1_w",
     ),
     RegisterDefinition(
@@ -340,7 +329,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         unit="W",
         device_class="power",
         state_class="measurement",
-        icon="mdi:lightning-bolt",
         translation_key="active_power_l2_w",
     ),
     RegisterDefinition(
@@ -354,7 +342,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         unit="W",
         device_class="power",
         state_class="measurement",
-        icon="mdi:lightning-bolt",
         translation_key="active_power_l3_w",
     ),
     RegisterDefinition(
@@ -369,7 +356,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         unit="kWh",
         device_class="energy",
         state_class="total_increasing",
-        icon="mdi:counter",
         translation_key="energy_total_kwh",
     ),
     RegisterDefinition(
@@ -384,7 +370,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         device_class="current",
         state_class="measurement",
         entity_category="diagnostic",
-        icon="mdi:current-ac",
         translation_key="session_max_current_a",
     ),
     RegisterDefinition(
@@ -398,7 +383,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         unit="A",
         device_class="current",
         entity_category="diagnostic",
-        icon="mdi:current-ac",
         translation_key="evse_min_current_a",
     ),
     RegisterDefinition(
@@ -412,7 +396,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         unit="A",
         device_class="current",
         entity_category="diagnostic",
-        icon="mdi:current-ac",
         translation_key="evse_max_current_a",
     ),
     RegisterDefinition(
@@ -426,7 +409,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         unit="A",
         device_class="current",
         entity_category="diagnostic",
-        icon="mdi:current-ac",
         translation_key="cable_max_current_a",
     ),
     RegisterDefinition(
@@ -440,7 +422,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         unit="A",
         device_class="current",
         entity_category="diagnostic",
-        icon="mdi:current-ac",
         translation_key="ev_max_current_a",
     ),
     RegisterDefinition(
@@ -454,7 +435,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         unit="Wh",
         device_class="energy",
         state_class="total",
-        icon="mdi:battery-clock",
         translation_key="charged_energy_wh",
     ),
     RegisterDefinition(
@@ -466,7 +446,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         data_type="uint32",
         entity="sensor",
         entity_category="diagnostic",
-        icon="mdi:clock-start",
         translation_key="session_start_time",
     ),
     RegisterDefinition(
@@ -481,7 +460,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         device_class="duration",
         state_class="measurement",
         entity_category="diagnostic",
-        icon="mdi:timer-outline",
         translation_key="session_duration_s",
     ),
     RegisterDefinition(
@@ -493,7 +471,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         data_type="uint32",
         entity="sensor",
         entity_category="diagnostic",
-        icon="mdi:clock-end",
         translation_key="session_end_time",
     ),
     RegisterDefinition(
@@ -505,7 +482,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         data_type="string",
         entity="sensor",
         entity_category="diagnostic",
-        icon="mdi:card-account-details",
         encoding="ascii",
         translation_key="session_user_id",
     ),
@@ -519,7 +495,6 @@ SENSOR_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         entity="sensor",
         device_class="enum",
         entity_category="diagnostic",
-        icon="mdi:car-connected",
         options=SMART_VEHICLE_STATE_MAP,
         optional=True,  # Only available on TQ-DM100
         translation_key="smart_vehicle_detected",
@@ -538,7 +513,6 @@ NUMBER_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         entity="number",
         unit="A",
         device_class="current",
-        icon="mdi:current-ac",
         writable=True,
         min_value=6,
         max_value=32,
@@ -554,7 +528,6 @@ NUMBER_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         data_type="uint16",
         entity="number",
         unit="s",
-        icon="mdi:timer-outline",
         writable=True,
         min_value=6,
         max_value=120,
@@ -571,7 +544,6 @@ NUMBER_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         entity="number",
         unit="A",
         device_class="current",
-        icon="mdi:speedometer",
         writable=True,
         write_only=True,
         min_value=0,
@@ -593,7 +565,6 @@ BUTTON_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         register_type="holding",
         data_type="uint16",
         entity="button",
-        icon="mdi:lan-connect",
         writable=True,
         write_only=True,
         translation_key="send_keepalive",
@@ -606,7 +577,6 @@ BUTTON_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         register_type="holding",
         data_type="uint16",
         entity="button",
-        icon="mdi:play",
         writable=True,
         write_only=True,
         translation_key="start_session",
@@ -619,7 +589,6 @@ BUTTON_REGISTERS: Final[tuple[RegisterDefinition, ...]] = (
         register_type="holding",
         data_type="uint16",
         entity="button",
-        icon="mdi:stop-circle",
         writable=True,
         write_only=True,
         translation_key="stop_session",
@@ -694,7 +663,6 @@ def _build_unite_sensor_registers() -> tuple[RegisterDefinition, ...]:
                 unit="V",
                 device_class="voltage",
                 state_class="measurement",
-                icon="mdi:sine-wave",
                 optional=True,
                 translation_key="voltage_l1",
             ),
@@ -709,7 +677,6 @@ def _build_unite_sensor_registers() -> tuple[RegisterDefinition, ...]:
                 unit="V",
                 device_class="voltage",
                 state_class="measurement",
-                icon="mdi:sine-wave",
                 optional=True,
                 translation_key="voltage_l2",
             ),
@@ -724,7 +691,6 @@ def _build_unite_sensor_registers() -> tuple[RegisterDefinition, ...]:
                 unit="V",
                 device_class="voltage",
                 state_class="measurement",
-                icon="mdi:sine-wave",
                 optional=True,
                 translation_key="voltage_l3",
             ),
@@ -740,7 +706,6 @@ def _build_unite_sensor_registers() -> tuple[RegisterDefinition, ...]:
                 device_class="power",
                 state_class="measurement",
                 entity_category="diagnostic",
-                icon="mdi:lightning-bolt",
                 optional=True,
                 translation_key="chargepoint_power_w",
             ),
@@ -758,7 +723,6 @@ def _build_unite_sensor_registers() -> tuple[RegisterDefinition, ...]:
                 entity="sensor",
                 device_class="enum",
                 entity_category="diagnostic",
-                icon="mdi:transmission-tower",
                 options=PHASE_COUNT_MAP,
                 optional=True,
                 translation_key="number_of_phases",
@@ -796,7 +760,6 @@ UNITE_PHASE_SWITCH_REGISTER: Final = RegisterDefinition(
     data_type="uint16",
     entity="switch",
     entity_category="config",
-    icon="mdi:transmission-tower",
     writable=True,
     write_only=True,
     optional=True,

--- a/custom_components/webasto_next_modbus/entity.py
+++ b/custom_components/webasto_next_modbus/entity.py
@@ -84,8 +84,6 @@ class WebastoRegisterEntity(CoordinatorEntity[WebastoDataCoordinator]):
             self._unique_prefix, self._device_name, self.coordinator
         )
 
-        if register.icon:
-            self._attr_icon = register.icon
         if register.entity_category:
             try:
                 self._attr_entity_category = EntityCategory(register.entity_category)

--- a/custom_components/webasto_next_modbus/icons.json
+++ b/custom_components/webasto_next_modbus/icons.json
@@ -1,0 +1,144 @@
+{
+  "entity": {
+    "sensor": {
+      "active_errors": {
+        "default": "mdi:alert"
+      },
+      "active_power_l1_w": {
+        "default": "mdi:lightning-bolt"
+      },
+      "active_power_l2_w": {
+        "default": "mdi:lightning-bolt"
+      },
+      "active_power_l3_w": {
+        "default": "mdi:lightning-bolt"
+      },
+      "active_power_total_w": {
+        "default": "mdi:lightning-bolt"
+      },
+      "cable_max_current_a": {
+        "default": "mdi:current-ac"
+      },
+      "cable_state": {
+        "default": "mdi:cable-data"
+      },
+      "charge_point_state": {
+        "default": "mdi:ev-station"
+      },
+      "charged_energy_wh": {
+        "default": "mdi:battery-clock"
+      },
+      "chargepoint_power_w": {
+        "default": "mdi:lightning-bolt"
+      },
+      "charging_state": {
+        "default": "mdi:battery-charging"
+      },
+      "comboard_firmware": {
+        "default": "mdi:chip"
+      },
+      "current_l1_a": {
+        "default": "mdi:current-ac"
+      },
+      "current_l2_a": {
+        "default": "mdi:current-ac"
+      },
+      "current_l3_a": {
+        "default": "mdi:current-ac"
+      },
+      "energy_total_kwh": {
+        "default": "mdi:counter"
+      },
+      "equipment_state": {
+        "default": "mdi:cog-outline"
+      },
+      "error_count": {
+        "default": "mdi:alert-circle"
+      },
+      "ev_max_current_a": {
+        "default": "mdi:current-ac"
+      },
+      "evse_max_current_a": {
+        "default": "mdi:current-ac"
+      },
+      "evse_min_current_a": {
+        "default": "mdi:current-ac"
+      },
+      "fault_code": {
+        "default": "mdi:alert"
+      },
+      "number_of_phases": {
+        "default": "mdi:transmission-tower"
+      },
+      "plug_cycles": {
+        "default": "mdi:ev-plug-type2"
+      },
+      "powerboard_firmware": {
+        "default": "mdi:chip"
+      },
+      "session_duration_s": {
+        "default": "mdi:timer-outline"
+      },
+      "session_end_time": {
+        "default": "mdi:clock-end"
+      },
+      "session_max_current_a": {
+        "default": "mdi:current-ac"
+      },
+      "session_start_time": {
+        "default": "mdi:clock-start"
+      },
+      "session_user_id": {
+        "default": "mdi:card-account-details"
+      },
+      "smart_vehicle_detected": {
+        "default": "mdi:car-connected"
+      },
+      "voltage_l1": {
+        "default": "mdi:sine-wave"
+      },
+      "voltage_l2": {
+        "default": "mdi:sine-wave"
+      },
+      "voltage_l3": {
+        "default": "mdi:sine-wave"
+      }
+    },
+    "number": {
+      "failsafe_current_a": {
+        "default": "mdi:current-ac"
+      },
+      "failsafe_timeout_s": {
+        "default": "mdi:timer-outline"
+      },
+      "led_brightness": {
+        "default": "mdi:led-on"
+      },
+      "set_current_a": {
+        "default": "mdi:speedometer"
+      }
+    },
+    "button": {
+      "restart_system": {
+        "default": "mdi:restart"
+      },
+      "send_keepalive": {
+        "default": "mdi:lan-connect"
+      },
+      "start_session": {
+        "default": "mdi:play"
+      },
+      "stop_session": {
+        "default": "mdi:stop-circle"
+      }
+    },
+    "switch": {
+      "free_charging": {
+        "default": "mdi:car-electric"
+      },
+      "phase_switch": {
+        "default": "mdi:transmission-tower"
+      }
+    }
+  }
+}

--- a/custom_components/webasto_next_modbus/number.py
+++ b/custom_components/webasto_next_modbus/number.py
@@ -279,7 +279,6 @@ class WebastoLedBrightness(WebastoRestEntity, NumberEntity):
     _attr_native_max_value = 100
     _attr_native_step = 1
     _attr_native_unit_of_measurement = PERCENTAGE
-    _attr_icon = "mdi:led-on"
     _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(

--- a/custom_components/webasto_next_modbus/quality_scale.yaml
+++ b/custom_components/webasto_next_modbus/quality_scale.yaml
@@ -67,7 +67,7 @@ rules:
       enough to warrant being disabled.
   entity-translations: done
   exception-translations: todo
-  icon-translations: todo
+  icon-translations: done
   reconfiguration-flow: done
   repair-issues:
     status: exempt

--- a/custom_components/webasto_next_modbus/sensor.py
+++ b/custom_components/webasto_next_modbus/sensor.py
@@ -25,7 +25,6 @@ class RestSensorDefinition:
 
     key: str
     value_fn: Callable[[RestData], StateType | list[str] | None]
-    icon: str | None = None
     device_class: str | None = None
     state_class: str | None = None
     unit: str | None = None
@@ -37,23 +36,19 @@ REST_SENSORS: list[RestSensorDefinition] = [
     RestSensorDefinition(
         key="comboard_firmware",
         value_fn=lambda d: d.comboard_sw_version,
-        icon="mdi:chip",
     ),
     RestSensorDefinition(
         key="powerboard_firmware",
         value_fn=lambda d: d.powerboard_sw_version,
-        icon="mdi:chip",
     ),
     RestSensorDefinition(
         key="plug_cycles",
         value_fn=lambda d: d.plug_cycles,
-        icon="mdi:ev-plug-type2",
         state_class="total_increasing",
     ),
     RestSensorDefinition(
         key="error_count",
         value_fn=lambda d: d.error_counter,
-        icon="mdi:alert-circle",
         state_class="total_increasing",
     ),
     RestSensorDefinition(
@@ -83,7 +78,6 @@ REST_SENSORS: list[RestSensorDefinition] = [
     RestSensorDefinition(
         key="active_errors",
         value_fn=lambda d: ", ".join(d.active_errors) if d.active_errors else "ok",
-        icon="mdi:alert",
         entity_category=None,
         translation_key="active_errors",
     ),
@@ -220,8 +214,6 @@ class WebastoRestSensor(WebastoRestEntity, SensorEntity):
         super().__init__(coordinator, host, unit_id, definition.key, device_name)
         self._definition = definition
 
-        if definition.icon:
-            self._attr_icon = definition.icon
         if definition.device_class:
             try:
                 self._attr_device_class = SensorDeviceClass(definition.device_class)

--- a/custom_components/webasto_next_modbus/switch.py
+++ b/custom_components/webasto_next_modbus/switch.py
@@ -124,7 +124,6 @@ class WebastoFreeChargingSwitch(WebastoRestEntity, SwitchEntity):
     _attr_has_entity_name = True
     _attr_device_class = SwitchDeviceClass.SWITCH
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_icon = "mdi:car-electric"
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary (Gold: icon-translations)

Moves all entity icons from `_attr_icon` / the `icon` dataclass field into **`icons.json`** keyed by entity `translation_key` — the Gold `icon-translations` rule.

- New `icons.json` with **44 icons** (sensor 34, number 4, button 4, switch 2), generated from the existing definitions.
- Dropped the `icon` field from `RegisterDefinition` and `RestSensorDefinition`; removed its application in the entity base and REST sensor; removed the three hardcoded `_attr_icon` entities (restart button, free-charging switch, LED brightness).
- Every `icons.json` key maps to an existing entity `translation_key`.
- `quality_scale.yaml`: `icon-translations` → done.

After this, only **`exception-translations`** remains before all Bronze→Platinum rules are done/exempt.

## Test plan

- [x] ruff/format/vulture clean; icons.json valid; const.py parses (run locally)
- [ ] CI green on 3.14.2 (mypy + hassfest icons.json validation)

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_