### PR TITLE
feat: translate user-facing exceptions (exception-translations)

### DIFF
--- a/custom_components/webasto_next_modbus/__init__.py
+++ b/custom_components/webasto_next_modbus/__init__.py
@@ -14,7 +14,11 @@ from homeassistant.components import persistent_notification
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+from homeassistant.exceptions import (
+    ConfigEntryNotReady,
+    HomeAssistantError,
+    ServiceValidationError,
+)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType
@@ -351,7 +355,7 @@ def _resolve_runtime(hass: HomeAssistant, call: ServiceCall) -> RuntimeData:
         if isinstance(getattr(entry, "runtime_data", None), RuntimeData)
     ]
     if not entries:
-        raise ValueError("Webasto Next Modbus is not configured")
+        raise ServiceValidationError(translation_domain=DOMAIN, translation_key="not_configured")
 
     if len(entries) == 1:
         return cast(RuntimeData, entries[0].runtime_data)
@@ -362,7 +366,7 @@ def _resolve_runtime(hass: HomeAssistant, call: ServiceCall) -> RuntimeData:
             if entry.entry_id == entry_id:
                 return cast(RuntimeData, entry.runtime_data)
 
-    raise ValueError("Multiple wallboxes configured – set config_entry_id in the service call")
+    raise ServiceValidationError(translation_domain=DOMAIN, translation_key="multiple_wallboxes")
 
 
 def _require_session_command_support(runtime: RuntimeData) -> None:
@@ -370,7 +374,8 @@ def _require_session_command_support(runtime: RuntimeData) -> None:
 
     if runtime.model != MODEL_NEXT:
         raise HomeAssistantError(
-            "Starting and stopping a charging session is only supported on the Webasto Next"
+            translation_domain=DOMAIN,
+            translation_key="session_command_unsupported",
         )
 
 
@@ -385,7 +390,11 @@ async def _async_service_set_current(call: ServiceCall) -> None:
     try:
         await runtime.bridge.async_write_register(register, value)
     except WebastoModbusError as err:
-        raise HomeAssistantError(f"Schreibvorgang fehlgeschlagen: {err}") from err
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="write_failed",
+            translation_placeholders={"error": str(err)},
+        ) from err
     async_dispatcher_send(
         call.hass,
         SIGNAL_REGISTER_WRITTEN,
@@ -407,7 +416,11 @@ async def _async_service_set_failsafe(call: ServiceCall) -> None:
     try:
         await runtime.bridge.async_write_register(amps_register, amps_value)
     except WebastoModbusError as err:
-        raise HomeAssistantError(f"Schreibvorgang fehlgeschlagen: {err}") from err
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="write_failed",
+            translation_placeholders={"error": str(err)},
+        ) from err
     async_dispatcher_send(
         call.hass,
         SIGNAL_REGISTER_WRITTEN,
@@ -426,7 +439,11 @@ async def _async_service_set_failsafe(call: ServiceCall) -> None:
         try:
             await runtime.bridge.async_write_register(timeout_register, timeout_value)
         except WebastoModbusError as err:
-            raise HomeAssistantError(f"Schreibvorgang fehlgeschlagen: {err}") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="write_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
         async_dispatcher_send(
             call.hass,
             SIGNAL_REGISTER_WRITTEN,
@@ -446,7 +463,11 @@ async def _async_service_send_keepalive(call: ServiceCall) -> None:
     try:
         await runtime.bridge.async_write_register(register, KEEPALIVE_TRIGGER_VALUE)
     except WebastoModbusError as err:
-        raise HomeAssistantError(f"Schreibvorgang fehlgeschlagen: {err}") from err
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="write_failed",
+            translation_placeholders={"error": str(err)},
+        ) from err
     async_fire_device_trigger(
         call.hass,
         runtime.device_slug,
@@ -465,7 +486,11 @@ async def _async_service_start_session(call: ServiceCall) -> None:
     try:
         await runtime.bridge.async_write_register(register, SESSION_COMMAND_START_VALUE)
     except WebastoModbusError as err:
-        raise HomeAssistantError(f"Schreibvorgang fehlgeschlagen: {err}") from err
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="write_failed",
+            translation_placeholders={"error": str(err)},
+        ) from err
     await runtime.coordinator.async_request_refresh()
 
 
@@ -478,7 +503,11 @@ async def _async_service_stop_session(call: ServiceCall) -> None:
     try:
         await runtime.bridge.async_write_register(register, SESSION_COMMAND_STOP_VALUE)
     except WebastoModbusError as err:
-        raise HomeAssistantError(f"Schreibvorgang fehlgeschlagen: {err}") from err
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="write_failed",
+            translation_placeholders={"error": str(err)},
+        ) from err
     await runtime.coordinator.async_request_refresh()
 
 
@@ -488,17 +517,21 @@ async def _async_service_set_led_brightness(call: ServiceCall) -> None:
 
     runtime = _resolve_runtime(call.hass, call)
     if not runtime.coordinator.rest_enabled:
-        raise HomeAssistantError("REST API is not enabled for this wallbox")
+        raise HomeAssistantError(translation_domain=DOMAIN, translation_key="rest_not_enabled")
 
     brightness = int(call.data["brightness"])
     rest_client = runtime.coordinator.rest_client
     if rest_client is None:
-        raise HomeAssistantError("REST client not available")
+        raise HomeAssistantError(translation_domain=DOMAIN, translation_key="rest_not_connected")
 
     try:
         await rest_client.set_led_brightness(brightness)
     except RestClientError as err:
-        raise HomeAssistantError(f"Failed to set LED brightness: {err}") from err
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="set_led_brightness_failed",
+            translation_placeholders={"error": str(err)},
+        ) from err
     await runtime.coordinator.async_refresh_rest_data()
 
 
@@ -508,17 +541,21 @@ async def _async_service_set_free_charging(call: ServiceCall) -> None:
 
     runtime = _resolve_runtime(call.hass, call)
     if not runtime.coordinator.rest_enabled:
-        raise HomeAssistantError("REST API is not enabled for this wallbox")
+        raise HomeAssistantError(translation_domain=DOMAIN, translation_key="rest_not_enabled")
 
     enabled = bool(call.data["enabled"])
     rest_client = runtime.coordinator.rest_client
     if rest_client is None:
-        raise HomeAssistantError("REST client not available")
+        raise HomeAssistantError(translation_domain=DOMAIN, translation_key="rest_not_connected")
 
     try:
         await rest_client.set_free_charging(enabled)
     except RestClientError as err:
-        raise HomeAssistantError(f"Failed to set free charging: {err}") from err
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="set_free_charging_failed",
+            translation_placeholders={"error": str(err)},
+        ) from err
     await runtime.coordinator.async_refresh_rest_data()
 
 
@@ -528,16 +565,20 @@ async def _async_service_restart_wallbox(call: ServiceCall) -> None:
 
     runtime = _resolve_runtime(call.hass, call)
     if not runtime.coordinator.rest_enabled:
-        raise HomeAssistantError("REST API is not enabled for this wallbox")
+        raise HomeAssistantError(translation_domain=DOMAIN, translation_key="rest_not_enabled")
 
     rest_client = runtime.coordinator.rest_client
     if rest_client is None:
-        raise HomeAssistantError("REST client not available")
+        raise HomeAssistantError(translation_domain=DOMAIN, translation_key="rest_not_connected")
 
     try:
         await rest_client.restart_system()
     except RestClientError as err:
-        raise HomeAssistantError(f"Failed to restart wallbox: {err}") from err
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="restart_failed",
+            translation_placeholders={"error": str(err)},
+        ) from err
 
 
 def _clamp(value: float, minimum: float, maximum: float) -> float:

--- a/custom_components/webasto_next_modbus/button.py
+++ b/custom_components/webasto_next_modbus/button.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import WebastoConfigEntry
 from .const import (
     CONF_UNIT_ID,
+    DOMAIN,
     KEEPALIVE_TRIGGER_VALUE,
     SESSION_COMMAND_START_VALUE,
     SESSION_COMMAND_STOP_VALUE,
@@ -109,9 +110,15 @@ class WebastoRestartButton(WebastoRestEntity, ButtonEntity):
     async def async_press(self) -> None:
         """Restart the wallbox via REST API."""
         if self._rest_client is None:
-            raise HomeAssistantError("REST API not connected")
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="rest_not_connected"
+            )
 
         try:
             await self._rest_client.restart_system()
         except Exception as err:
-            raise HomeAssistantError(f"Failed to restart wallbox: {err}") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="restart_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err

--- a/custom_components/webasto_next_modbus/entity.py
+++ b/custom_components/webasto_next_modbus/entity.py
@@ -109,7 +109,11 @@ class WebastoRegisterEntity(CoordinatorEntity[WebastoDataCoordinator]):
         try:
             await self._bridge.async_write_register(self._register, value)
         except WebastoModbusError as err:
-            raise HomeAssistantError(f"Schreibvorgang fehlgeschlagen: {err}") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="write_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
 
     def get_coordinator_value(self) -> Any:
         """Helper returning the latest coordinator value for this register."""

--- a/custom_components/webasto_next_modbus/number.py
+++ b/custom_components/webasto_next_modbus/number.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import WebastoConfigEntry
 from .const import (
     CONF_UNIT_ID,
+    DOMAIN,
     SIGNAL_REGISTER_WRITTEN,
     RegisterDefinition,
     get_number_registers,
@@ -317,7 +318,9 @@ class WebastoLedBrightness(WebastoRestEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Set LED brightness via REST API."""
         if self._rest_client is None:
-            raise HomeAssistantError("REST API not connected")
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="rest_not_connected"
+            )
 
         int_value = int(round(value))
         self._pending_value = int_value
@@ -331,7 +334,11 @@ class WebastoLedBrightness(WebastoRestEntity, NumberEntity):
             self._pending_value = None
             if self.hass is not None:
                 self._handle_coordinator_update()
-            raise HomeAssistantError(f"Failed to set LED brightness: {err}") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_led_brightness_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
 
         # Re-fetch the REST data now (regular polling is throttled) so the UI
         # shows the value the wallbox actually has.

--- a/custom_components/webasto_next_modbus/quality_scale.yaml
+++ b/custom_components/webasto_next_modbus/quality_scale.yaml
@@ -66,7 +66,7 @@ rules:
       All entities are low-cardinality and useful by default; none are noisy
       enough to warrant being disabled.
   entity-translations: done
-  exception-translations: todo
+  exception-translations: done
   icon-translations: done
   reconfiguration-flow: done
   repair-issues:

--- a/custom_components/webasto_next_modbus/switch.py
+++ b/custom_components/webasto_next_modbus/switch.py
@@ -9,7 +9,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import WebastoConfigEntry
-from .const import CONF_UNIT_ID, RegisterDefinition, get_switch_registers
+from .const import CONF_UNIT_ID, DOMAIN, RegisterDefinition, get_switch_registers
 from .coordinator import WebastoDataCoordinator
 from .entity import WebastoRegisterEntity, WebastoRestEntity
 from .hub import ModbusBridge
@@ -164,7 +164,9 @@ class WebastoFreeChargingSwitch(WebastoRestEntity, SwitchEntity):
     async def _set_free_charging(self, enabled: bool) -> None:
         """Set free charging state via REST API."""
         if self._rest_client is None:
-            raise HomeAssistantError("REST API not connected")
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="rest_not_connected"
+            )
 
         self._pending_state = enabled
         self._attr_is_on = enabled
@@ -175,7 +177,11 @@ class WebastoFreeChargingSwitch(WebastoRestEntity, SwitchEntity):
         except Exception as err:
             self._pending_state = None
             self._handle_coordinator_update()
-            raise HomeAssistantError(f"Failed to set free charging: {err}") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_free_charging_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
 
         # Re-fetch the REST data now (regular polling is throttled) so the UI
         # shows the state the wallbox actually has.

--- a/custom_components/webasto_next_modbus/text.py
+++ b/custom_components/webasto_next_modbus/text.py
@@ -88,12 +88,18 @@ class WebastoFreeChargingTagIdText(WebastoRestEntity, TextEntity):
     async def async_set_value(self, value: str) -> None:
         """Set the text value."""
         if not self.coordinator.rest_client:
-            raise HomeAssistantError("REST API not connected")
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="rest_not_connected"
+            )
 
         try:
             await self.coordinator.rest_client.set_free_charging_tag_id(value)
         except Exception as err:
-            raise HomeAssistantError(f"Failed to set free charging tag ID: {err}") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_tag_id_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
         # Regular REST polling is throttled; re-fetch now so the entity reflects
         # what the wallbox actually stored instead of the stale cached value.
         await self.coordinator.async_refresh_rest_data()

--- a/custom_components/webasto_next_modbus/translations/de.json
+++ b/custom_components/webasto_next_modbus/translations/de.json
@@ -300,5 +300,37 @@
     "abort": {
       "missing_dependency": "Das benötigte Paket 'voluptuous' fehlt in dieser Home Assistant Umgebung."
     }
+  },
+  "exceptions": {
+    "not_configured": {
+      "message": "Webasto Next / Unite ist nicht eingerichtet."
+    },
+    "multiple_wallboxes": {
+      "message": "Es sind mehrere Wallboxen eingerichtet. Bitte config_entry_id im Dienstaufruf angeben."
+    },
+    "session_command_unsupported": {
+      "message": "Das Starten und Stoppen einer Ladesitzung wird nur von der Webasto Next unterstützt."
+    },
+    "write_failed": {
+      "message": "Schreibvorgang an der Wallbox fehlgeschlagen: {error}"
+    },
+    "rest_not_enabled": {
+      "message": "Die REST-API ist für diese Wallbox nicht aktiviert."
+    },
+    "rest_not_connected": {
+      "message": "Die REST-API ist nicht verbunden."
+    },
+    "set_led_brightness_failed": {
+      "message": "LED-Helligkeit konnte nicht gesetzt werden: {error}"
+    },
+    "set_free_charging_failed": {
+      "message": "Free Charging konnte nicht geändert werden: {error}"
+    },
+    "set_tag_id_failed": {
+      "message": "Free-Charging-Tag-ID konnte nicht gesetzt werden: {error}"
+    },
+    "restart_failed": {
+      "message": "Neustart der Wallbox fehlgeschlagen: {error}"
+    }
   }
 }

--- a/custom_components/webasto_next_modbus/translations/en.json
+++ b/custom_components/webasto_next_modbus/translations/en.json
@@ -299,5 +299,37 @@
         "name": "Three-phase charging"
       }
     }
+  },
+  "exceptions": {
+    "not_configured": {
+      "message": "Webasto Next / Unite is not configured."
+    },
+    "multiple_wallboxes": {
+      "message": "Multiple wallboxes are configured. Set config_entry_id in the service call."
+    },
+    "session_command_unsupported": {
+      "message": "Starting and stopping a charging session is only supported on the Webasto Next."
+    },
+    "write_failed": {
+      "message": "Writing to the wallbox failed: {error}"
+    },
+    "rest_not_enabled": {
+      "message": "The REST API is not enabled for this wallbox."
+    },
+    "rest_not_connected": {
+      "message": "The REST API is not connected."
+    },
+    "set_led_brightness_failed": {
+      "message": "Failed to set the LED brightness: {error}"
+    },
+    "set_free_charging_failed": {
+      "message": "Failed to change free charging: {error}"
+    },
+    "set_tag_id_failed": {
+      "message": "Failed to set the free-charging tag ID: {error}"
+    },
+    "restart_failed": {
+      "message": "Failed to restart the wallbox: {error}"
+    }
   }
 }

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from custom_components.webasto_next_modbus import (
     DOMAIN,
@@ -108,7 +108,7 @@ def test_resolve_runtime_requires_entry_id() -> None:
     hass = _make_hass({"entry_a": runtime_a, "entry_b": runtime_b})
 
     call_missing = _make_call({})
-    with pytest.raises(ValueError):
+    with pytest.raises(ServiceValidationError):
         _resolve_runtime(hass, call_missing)
 
     call = _make_call({"config_entry_id": "entry_b"})
@@ -121,7 +121,7 @@ def test_resolve_runtime_missing_runtime_data() -> None:
     hass = _make_hass({"entry": cast(RuntimeData, SimpleNamespace())})
     call = _make_call({})
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ServiceValidationError):
         _resolve_runtime(hass, call)
 
 


### PR DESCRIPTION
## Summary (Gold: exception-translations — the last rule)

User-facing exceptions now carry translation keys. Raises in the service handlers and entity actions use `HomeAssistantError` / `ServiceValidationError` with `translation_domain` + `translation_key` (and an `{error}` placeholder where they wrap a cause); messages live in a new `exceptions` block in `en.json` / `de.json` (10 keys). The service resolver's "not configured" / "multiple wallboxes" errors become `ServiceValidationError`. Internal invariants in `hub.py` / `rest_client.py` stay plain `ValueError` (not user-facing).

`quality_scale.yaml`: `exception-translations` → done.

**🎉 All 52 quality-scale rules are now `done` or `exempt`** (Bronze → Platinum). The manifest can be bumped next.

## Test plan

- [x] ruff/format/codespell/vulture clean; en/de valid JSON with 10 exception keys; no `todo` left in quality_scale.yaml (run locally)
- [x] resolver tests updated to expect `ServiceValidationError`
- [ ] CI green on 3.14.2 (mypy + tests + hassfest)

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_