### PR TITLE
chore: declare platinum quality scale

### DIFF
--- a/custom_components/webasto_next_modbus/manifest.json
+++ b/custom_components/webasto_next_modbus/manifest.json
@@ -14,7 +14,7 @@
     "pymodbus",
     "custom_components.webasto_next_modbus"
   ],
-  "quality_scale": "silver",
+  "quality_scale": "platinum",
   "requirements": [
     "pymodbus>=3.11.2,<3.12"
   ],


### PR DESCRIPTION
## Summary

Bumps `manifest.json` `quality_scale` from **silver → platinum**.

All 52 quality-scale rules (Bronze → Platinum) are `done` or `exempt`, tracked rule-by-rule in `quality_scale.yaml`:
- **Bronze/Silver**: config/reconfigure/reauth flows, runtime-data, test-before-setup/configure, entity-unique-id, has-entity-name, parallel-updates, action-setup, log-when-unavailable, …
- **Gold**: devices, diagnostics, entity-category/device-class, entity/icon/exception translations, reconfiguration-flow; discovery/dynamic-devices/stale-devices/repair-issues exempt with justification.
- **Platinum**: async-dependency, inject-websession, strict-typing.

Self-declared (custom/HACS integration; HA only formally scores core integrations).

## Test plan

- [x] manifest valid JSON; quality_scale.yaml has no `todo` (run locally)
- [ ] CI green (hassfest validates the declared tier against quality_scale.yaml)

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_