### PR TITLE
chore: prepare 1.3.0 (version bump + changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Reconfigure flow**: change a wallbox's host, port, unit ID or name from *Settings → Devices & Services → ⋮ → Reconfigure* without removing and re-adding the integration.
+- **Reauthentication flow**: when the wallbox rejects the REST API credentials, Home Assistant now starts a guided reauth dialog to enter new ones (replacing the previous repair issue). The Modbus side keeps working throughout.
+- **Charging binary sensor** (`device_class: battery_charging`) — a simple on/off entity for dashboards and automations, alongside the existing Connected sensor.
+- **New device triggers**: *cable connected*, *cable disconnected* and *fault occurred* (in addition to charging started/stopped, connection lost/restored and keep-alive sent). All device triggers are now translated (English/German), and the event-notification blueprint can fire on them.
+
+### Changed
+
+- **Quality scale raised to Platinum.** Every Bronze→Platinum rule is now met or exempt (tracked in `quality_scale.yaml`): the REST client uses Home Assistant's shared aiohttp session (`inject-websession`), the code is strictly typed (`strict` mypy + `py.typed`), entity icons and user-facing exceptions are translated, `PARALLEL_UPDATES` is declared on every platform, and service actions are registered in `async_setup`.
+
+### Fixed
+
+- **Forward-compatibility (HA 2026.6)**: the reconfigure/reauth flows update the entry and rely on the existing update listener for a single reload, avoiding the now-deprecated config-entry-listener-plus-reloading-method combination that becomes an error in 2026.12.
+- **Example blueprints**: fixed the FastCharge/FullCharge, Charge-Target and Charge-Until-Full blueprints, which referenced blueprint inputs in templates in a way that failed at runtime; all four blueprints were modernised to the current `triggers`/`conditions`/`actions` syntax and are now guarded by a lint test.
+
+### Internal
+
+- Dependabot tuned: monthly pip cadence, a 7-day cooldown, and auto-merge for low-risk (patch/minor) updates once CI passes.
+- Entity icons moved to `icons.json`; exceptions carry translation keys.
+
 ## [1.2.0] - 2026-05-24
 
 ### Added

--- a/custom_components/webasto_next_modbus/manifest.json
+++ b/custom_components/webasto_next_modbus/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "pymodbus>=3.11.2,<3.12"
   ],
-  "version": "1.2.0"
+  "version": "1.3.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "webasto-next-modbus"
-version = "1.2.0"
+version = "1.3.0"
 description = "Home Assistant integration for Webasto Next / Ampure Unite wallboxes via Modbus TCP and REST API"
 authors = [{ name = "Webasto Next maintainers" }]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Prepares the **1.3.0** release.

- Bumps `manifest.json` and `pyproject.toml` `1.2.0 → 1.3.0`.
- Adds the `## [Unreleased]` CHANGELOG section (the release workflow extracts it for `v1.3.0-beta.*` pre-releases), covering: reconfigure + reauth flows, Platinum quality scale (inject-websession, strict typing, icon/exception translations, parallel-updates, action-setup), charging binary sensor, new cable/fault device triggers, the 2026.6 double-reload forward-compat fix, the blueprint fixes/modernisation, and the Dependabot tuning.

No breaking changes since 1.2.0 → minor bump.

## Release plan
After merge: tag **`v1.3.0-beta.1`** on the merge commit → the release workflow publishes a GitHub pre-release (HACS "Show beta versions") with the `[Unreleased]` notes.

## Test plan

- [x] manifest + pyproject at 1.3.0; CHANGELOG mdformat-clean (run locally)
- [ ] CI green

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_