### PR TITLE
fix: bring REST/startup logging up to quality-scale level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 - **Forward-compatibility (HA 2026.6)**: the reconfigure/reauth flows update the entry and rely on the existing update listener for a single reload, avoiding the now-deprecated config-entry-listener-plus-reloading-method combination that becomes an error in 2026.12.
 - **Example blueprints**: fixed the FastCharge/FullCharge, Charge-Target and Charge-Until-Full blueprints, which referenced blueprint inputs in templates in a way that failed at runtime; all four blueprints were modernised to the current `triggers`/`conditions`/`actions` syntax and are now guarded by a lint test.
+- **REST API logging**: request timeouts are now retried like other transient errors instead of bubbling up as a blank `Failed to fetch <section> section:` warning, and per-section fetch failures (which keep partial/stale data) log at debug instead of repeating a warning every poll. Genuine REST outages are still surfaced once via the throttled coordinator warning.
+- **Quieter startup**: the one-time "integration loaded from &lt;path&gt;" message is now logged at debug instead of warning.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 - **Forward-compatibility (HA 2026.6)**: the reconfigure/reauth flows update the entry and rely on the existing update listener for a single reload, avoiding the now-deprecated config-entry-listener-plus-reloading-method combination that becomes an error in 2026.12.
 - **Example blueprints**: fixed the FastCharge/FullCharge, Charge-Target and Charge-Until-Full blueprints, which referenced blueprint inputs in templates in a way that failed at runtime; all four blueprints were modernised to the current `triggers`/`conditions`/`actions` syntax and are now guarded by a lint test.
-- **REST API logging**: request timeouts are now retried like other transient errors instead of bubbling up as a blank `Failed to fetch <section> section:` warning, and per-section fetch failures (which keep partial/stale data) log at debug instead of repeating a warning every poll. Genuine REST outages are still surfaced once via the throttled coordinator warning.
+- **REST API logging**: request timeouts are now retried like other transient errors instead of bubbling up as a blank `Failed to fetch <section> section:` warning, and per-section fetch failures (which keep partial/stale data) log at debug instead of repeating a warning every poll. Per-attempt retries also log at debug now (only the final outcome matters). Genuine REST outages are still surfaced once via the throttled coordinator warning.
 - **Quieter startup**: the one-time "integration loaded from &lt;path&gt;" message is now logged at debug instead of warning.
 
 ### Internal

--- a/custom_components/webasto_next_modbus/__init__.py
+++ b/custom_components/webasto_next_modbus/__init__.py
@@ -111,7 +111,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: WebastoConfigEntry) -> b
 
     global _INTEGRATION_PATH_LOGGED
     if not _INTEGRATION_PATH_LOGGED:
-        _LOGGER.warning("Webasto Next Modbus integration loaded from %s", _INTEGRATION_PATH)
+        _LOGGER.debug("Webasto Next Modbus integration loaded from %s", _INTEGRATION_PATH)
         _INTEGRATION_PATH_LOGGED = True
 
     host = entry.data[CONF_HOST]

--- a/custom_components/webasto_next_modbus/rest_client.py
+++ b/custom_components/webasto_next_modbus/rest_client.py
@@ -377,8 +377,8 @@ class RestClient:
                 raise
             except (aiohttp.ClientError, TimeoutError) as err:
                 last_error = err
-                _LOGGER.warning(
-                    "Attempt %s/%s to %s failed: %s",
+                _LOGGER.debug(
+                    "Attempt %s/%s to %s failed: %r",
                     attempt,
                     MAX_RETRY_ATTEMPTS,
                     f"{method} {path}",

--- a/custom_components/webasto_next_modbus/rest_client.py
+++ b/custom_components/webasto_next_modbus/rest_client.py
@@ -164,21 +164,21 @@ class RestClient:
             system_fields = await self._get_section("system")
             self._parse_system_fields(system_fields, values)
         except Exception as err:
-            _LOGGER.warning("Failed to fetch system section: %s", err)
+            _LOGGER.debug("Failed to fetch system section: %r", err)
 
         # Fetch auth section for free charging
         try:
             auth_fields = await self._get_section("auth")
             self._parse_auth_fields(auth_fields, values)
         except Exception as err:
-            _LOGGER.warning("Failed to fetch auth section: %s", err)
+            _LOGGER.debug("Failed to fetch auth section: %r", err)
 
         # Fetch current errors
         try:
             errors = await self._get_current_errors()
             values["active_errors"] = errors
         except Exception as err:
-            _LOGGER.warning("Failed to fetch current errors: %s", err)
+            _LOGGER.debug("Failed to fetch current errors: %r", err)
 
         return RestData(**values)
 
@@ -375,7 +375,7 @@ class RestClient:
 
             except asyncio.CancelledError:
                 raise
-            except aiohttp.ClientError as err:
+            except (aiohttp.ClientError, TimeoutError) as err:
                 last_error = err
                 _LOGGER.warning(
                     "Attempt %s/%s to %s failed: %s",


### PR DESCRIPTION
## Summary

Brings logging in line with the `log-when-unavailable` quality-scale rule, fixing the warnings a beta tester saw on a working install:

- **Blank `Failed to fetch <section> section:` warning** — caused by a bare `TimeoutError` (whose `str()` is empty) bubbling past the retry loop, which only caught `aiohttp.ClientError`. Now timeouts are retried too, and per-section failures (which keep partial/stale data) log at `debug` with `%r` so they are never blank and never spam a warning every poll. Real REST outages still surface once via the throttled coordinator warning (they fail in `_ensure_token()` before the per-section handlers).
- **Per-attempt retry spam** — each retry attempt logged at WARNING (up to 3 per request). Retry mechanics are now `debug`; only the final outcome matters.
- **Startup noise** — the one-time "integration loaded from \<path\>" message moved from WARNING to `debug`.

CHANGELOG `[Unreleased]` updated. Targets the upcoming **v1.3.0** (will ship in beta.2 for verification).

## Test plan

- [ ] CI green (ruff, mypy strict, hassfest, pytest)
- [ ] Verify on hardware: no blank `Failed to fetch system section:` warning, firmware/diagnostic REST sensors behave as before

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_