### PR TITLE
chore: release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.3.0] - 2026-05-27
 
 ### Added
 


### PR DESCRIPTION
## Summary

Promotes the `[Unreleased]` changelog section to **`[1.3.0] - 2026-05-27`** for the stable release. Manifest and `pyproject.toml` are already at `1.3.0` (from #80), so this is the only change needed.

Verified on hardware via the `v1.3.0-beta.2` pre-release: the logging fixes resolved the warnings and Modbus/REST behave as expected.

After merge, push the `v1.3.0` tag on `main` to trigger the final (non-pre-) release.

## Test plan

- [ ] CI green

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_