### PR TITLE
docs: bring user and architecture docs up to Platinum level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Documentation aligned with the HA quality scale Gold/Platinum doc rules: new **Data updates** section (10 s Modbus / 60 s REST / Life Bit cadence) and a consolidated **Known limitations** section in the README; a copy-paste-ready custom YAML automation example using a service action and a device trigger; the Configuration list now documents the *Model* selector (Next vs Unite) and the *Reconfigure* / *Configure* entry points. A stale "a repair issue is raised" note in the README was replaced with the actual reauth-flow behaviour shipped in 1.3.0.
+- `docs/architecture.md` updated to reflect the 1.3.0 surface: reconfigure & reauth flows, the Charging binary sensor, the eight device triggers, the Unite-specific register differences confirmed in [#37](https://github.com/tomwellnitz/Webasto-Next-Modbus/issues/37), and the Platinum quality scale rules (strict typing, `inject-websession`, icon/exception translations, action-setup).
+- `docs/support.md`: the duplicated "Known limitations" subsection now defers to the README (which is now the single, sourced reference).
+
 ## [1.3.0] - 2026-05-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -69,9 +69,12 @@ Modbus TCP is **disabled by default** on the Webasto Next / Unite. Enable it fir
    - **Host** — IP address or hostname (e.g. `192.168.1.50`).
    - **Port** — default `502`.
    - **Unit ID** — default `255`.
+   - **Model** — *Webasto Next* (default) or *Webasto / Ampure Unite*. Existing installs stay on Next; pick Unite for an Ampure / Webasto Unite (see [Supported hardware](#supported-hardware) — the Unite uses a different register layout).
    - **Variant** — your hardware power rating (11 kW or 22 kW).
 
 > The wallboxes do not advertise themselves on the network, so they are added manually by IP address; there is no auto-discovery.
+
+The host, port, unit ID and entry name can be changed later without removing the integration via *Settings → Devices & Services → Webasto Next / Unite → ⋮ → **Reconfigure***. Model, variant, scan interval and REST settings live under *⋮ → **Configure***.
 
 ### Optional: REST API
 
@@ -80,7 +83,13 @@ The REST API exposes features that are not available over Modbus (LED control, f
 1. Open the integration entry → three-dot menu → **Configure**.
 2. Enable **REST API features** and enter the wallbox web-interface credentials (username default `admin`).
 
-Credentials are stored in the Home Assistant config entry and redacted from downloaded diagnostics. If the wallbox later rejects them, a repair issue is raised so you can update the password; the Modbus side keeps working regardless.
+Credentials are stored in the Home Assistant config entry and redacted from downloaded diagnostics. If the wallbox later rejects them, Home Assistant starts a guided **reauthentication** dialog so you can enter new ones; the Modbus side keeps working regardless. The wallbox's web interface uses a self-signed certificate, so the integration disables TLS verification for that local HTTPS endpoint.
+
+## Data updates
+
+- **Modbus telemetry** is polled every **10 seconds** by default. The interval is configurable via *⋮ → **Configure** → Scan interval*.
+- **REST API data** (firmware info, LED brightness, free charging, diagnostics, active errors) is fetched every **60 seconds**. If the wallbox's web interface is unreachable at startup, the integration retries the REST connection every **5 minutes** until it succeeds; the Modbus side is independent and keeps working.
+- The **"Life Bit" keep-alive** runs continuously in the background: the integration writes `1` to the keep-alive register and polls until the wallbox clears it to `0`, preventing the wallbox from dropping into fail-safe mode. The cadence follows the wallbox's own clear-cycle.
 
 ## Entities
 
@@ -133,9 +142,49 @@ Ready-to-import blueprints live under **Settings → Automations & Scenes → Bl
 - **Charge target (kWh)** — charge a set amount of energy, then stop.
 - **Charge until full** — stop automatically once charging power drops below a threshold.
 - **Solar surplus optimizer** — adjust the charging current to grid export to maximise self-consumption.
-- **Event notifications** — send a mobile notification on charging or connectivity events (charging started/stopped, connection lost/restored, keep-alive sent).
+- **Event notifications** — send a mobile notification on wallbox events (charging started/stopped, connection lost/restored, keep-alive sent, cable connected/disconnected, fault occurred).
 
-Device triggers for charging start/stop, connection state, cable connected/disconnected and fault-occurred are available for your own automations.
+Device triggers for charging start/stop, connection state, cable connected/disconnected and fault occurred are available for your own automations.
+
+### Custom YAML example
+
+For fully custom logic the integration's services and device triggers are usable directly. Replace `<your wallbox device id>` with the device ID from *Developer Tools → States → your wallbox* (or pick it interactively in the automation editor).
+
+```yaml
+automation:
+  - alias: Webasto — cap charging current at night
+    triggers:
+      - trigger: time
+        at: "23:00:00"
+    actions:
+      - action: webasto_next_modbus.set_current
+        data:
+          amps: 6
+
+  - alias: Webasto — fault alert
+    triggers:
+      - trigger: device
+        domain: webasto_next_modbus
+        device_id: <your wallbox device id>
+        type: fault_occurred
+    actions:
+      - action: notify.mobile_app_my_phone
+        data:
+          title: Webasto fault
+          message: "Fault code {{ trigger.event.data.fault_code }}"
+```
+
+## Known limitations
+
+- **One Modbus client at a time** — the Webasto Next / Unite accepts only one Modbus TCP connection. If another client (EVCC, a manual `modbus:` block, another HA add-on) is holding the slot, this integration cannot connect.
+- **Modbus is off by default on the wallbox** — it must be enabled once in the wallbox web interface (expert / installer view) before setup will succeed ([#36](https://github.com/tomwellnitz/Webasto-Next-Modbus/issues/36)).
+- **No auto-discovery** — the wallboxes do not advertise themselves over mDNS / zeroconf, so they are added manually by IP address or hostname.
+- **Use a static address** — configure a DHCP reservation or use a hostname so the wallbox stays reachable; if the address changes, run the integration's *Reconfigure* flow.
+- **Unite three-phase switching is firmware-dependent** — the holding register used by the switch (`405`) is not in the vendor's Modbus spec. Switching and read-back are confirmed on firmware **3.187** ([#37](https://github.com/tomwellnitz/Webasto-Next-Modbus/issues/37)); on other Unite firmwares the behavior is unverified.
+- **REST API uses a self-signed certificate** — TLS verification is disabled for the wallbox's local web interface (required by the embedded HTTPS endpoint). REST credentials are stored in the config entry and redacted from diagnostics.
+- **Optional registers vary by firmware** — registers a given firmware doesn't implement are auto-detected and dropped from the read plan; the corresponding entities become unavailable rather than spamming errors.
+- **Firmware downgrades are blocked by the vendor** — community reports indicate Webasto does not allow rolling back to an older firmware once updated ([#37](https://github.com/tomwellnitz/Webasto-Next-Modbus/issues/37)).
+- **One device per config entry** — to manage several wallboxes, add the integration multiple times (one config entry per wallbox).
 
 ## Troubleshooting
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,14 +11,18 @@ This document captures architectural goals, the communication protocols (Modbus 
 
 ## Functional requirements
 
-- **Configuration flow** – Guided setup that collects host, port, unit ID, scan interval, and hardware variant while validating connectivity inline. Optional REST API credentials.
-- **Modbus communication** – Async TCP client (pymodbus) with request batching, retry/backoff, and deterministic reconnect behaviour.
-- **REST API communication** – Optional async HTTPS client (aiohttp) with JWT authentication, auto token refresh, and graceful degradation.
-- **Entities** – Sensors for live telemetry and metadata, numbers for writable settings, switches for configuration toggles, and buttons for manual keep-alive and session control.
-- **Services** – Dedicated helpers (`set_current`, `set_failsafe`, `send_keepalive`, `start_session`, `stop_session`) for Modbus, plus REST API services (`set_led_brightness`, `set_free_charging`, `restart_wallbox`).
+- **Configuration flow** – Guided setup that collects host, port, unit ID, model (Next vs Unite), variant, and scan interval, validating connectivity inline. Optional REST API credentials.
+- **Reconfigure & reauth flows** – `async_step_reconfigure` allows changing host, port, unit ID and entry name in place (no remove-and-readd). `async_step_reauth` is started automatically when the wallbox rejects REST credentials (HTTP 401) to walk the user through entering new ones; the Modbus side keeps working throughout.
+- **Modbus communication** – Async TCP client (pymodbus) with request batching, retry/backoff, and deterministic reconnect behaviour. Modbus exception responses are distinguished from transport errors: an unsupported optional block is auto-detected and dropped from the read plan, while a required block raises a typed `WebastoModbusDeviceError`.
+- **REST API communication** – Optional async HTTPS client (aiohttp) sharing Home Assistant's `async_get_clientsession`, with JWT authentication, auto token refresh, retry-with-backoff for transient errors, and graceful degradation.
+- **Entities** – Sensors for live telemetry and metadata; numbers for writable settings; switches for free-charging and (Unite only) three-phase mode; buttons for manual keep-alive, session control, and (REST) restart; text for the free-charging tag ID; binary sensors for **Connected** (always-available connectivity) and **Charging** (`battery_charging` device class).
+- **Services** – Dedicated helpers (`set_current`, `set_failsafe`, `send_keepalive`, `start_session`, `stop_session`) for Modbus, plus REST API services (`set_led_brightness`, `set_free_charging`, `restart_wallbox`). Registered in `async_setup` so they exist before any config entry is set up.
+- **Device triggers** – `charging_started`, `charging_stopped`, `connection_lost`, `connection_restored`, `keepalive_sent`, `cable_connected`, `cable_disconnected`, `fault_occurred` (with English / German translations), used by the bundled blueprints and available for user automations.
+- **Diagnostics** – Downloadable config-entry diagnostics with REST credentials redacted.
+- **Quality scale** – Platinum: strict typing (`mypy --strict` + `py.typed`), `inject-websession` (HA shared aiohttp session), async-dependency, icon translations (`icons.json`), exception translations, action-setup, `PARALLEL_UPDATES` declared on every platform.
 - **Extensibility** – Centralised register descriptions drive entity creation so new datapoints require minimal boilerplate.
-- **Testing** – Pytest suite with Modbus fixtures covering the config flow, coordinator, entities, services, and device triggers.
-- **Documentation** – User-facing README plus architecture and development guides for maintainers.
+- **Testing** – Pytest suite with virtual-wallbox fixtures covering the config flow (incl. reconfigure and reauth), coordinator, entities, services, and device triggers; `pytest-homeassistant-custom-component` provides a realistic Home Assistant core.
+- **Documentation** – User-facing README and support/troubleshooting page, plus architecture and development guides for maintainers.
 
 ## Domain model
 
@@ -72,18 +76,34 @@ The register ranges are derived from community research and vendor documentation
 | `start_session` | 5006 | 1 | Start charging session |
 | `stop_session` | 5006 | 2 | Stop charging session |
 
-*Note: Voltage sensors and some other registers from the vendor PDF are not exposed as they returned invalid data in testing.*
+*Note: Voltage sensors and some other registers from the vendor PDF are not exposed on the Next as they returned invalid data in testing.*
+
+### Webasto / Ampure Unite differences (v1.2.0+)
+
+Picking the **Unite** model in the config flow switches to a corrected register map (community readouts from issue [#37](https://github.com/tomwellnitz/Webasto-Next-Modbus/issues/37), confirmed on firmware 3.156 and 3.187):
+
+- The telemetry block (~100–1513) is read as **input registers** on the Unite; the Next answers on both holding and input, the Unite only on input. This is why a Unite configured as "Next" reads all sensors as `0`.
+- `energy_total_kwh` is decoded as a 32-bit value across registers `1036`+`1037` in **0.1 kWh** units.
+- `charged_energy_wh` (`1502`) is a `uint32` on the Unite.
+- `charge_point_state` (`1000`) uses the Unite's 9-state enum.
+- Next-only registers (session user id `1600`, smart-vehicle-detected `1620`, start/stop-session command `5006`) are not read on the Unite.
+- Unite-only optional registers: per-phase voltage `1014`/`1016`/`1018` (volts), chargepoint power `400`, installed phase count `404`, and the active phase mode at `405` — written by the "Three-phase charging" switch (`0` = single-phase, `1` = three-phase) and read back from the same register. Register `405` is undocumented in the vendor spec; phase switching has been confirmed on firmware 3.187 (#37) and the switch carries `_attr_assumed_state = True` because behaviour on other Unite firmwares is unverified.
 
 ## Software components
 
-- `__init__.py` – Integration setup/teardown, service registration, and coordinator bootstrap. Handles connection retries and starts the Life Bit loop.
-- `const.py` – Constants, register descriptions, and enum mappings. The integration version lives in `manifest.json` / `pyproject.toml`, not here.
+- `__init__.py` – Integration setup/teardown, service registration in `async_setup` (action-setup rule), and coordinator bootstrap. Handles connection retries and starts the Life Bit loop.
+- `const.py` – Constants, register descriptions (including the Unite-specific layout), and enum mappings. The integration version lives in `manifest.json` / `pyproject.toml`, not here.
 - `hub.py` – `ModbusBridge` abstraction that wraps the async client, handles reconnect logic, exposes read/write helpers, and manages the background "Life Bit" loop.
-- `rest_client.py` – `WebastoRestClient` for optional REST API communication. Handles JWT authentication, token refresh, and API calls for features not available via Modbus.
-- `coordinator.py` – `DataUpdateCoordinator` implementation that schedules read cycles, normalises raw register values, and optionally fetches REST API data.
-- `config_flow.py` – User and options flows with validation and duplicate protection. Includes optional REST API credential configuration.
-- Platform modules (`sensor.py`, `number.py`, `button.py`, `switch.py`, `binary_sensor.py`, `text.py`) – Entity classes backed by static descriptions. `binary_sensor.py` exposes the always-available **Connected** connectivity sensor; the `switch`/`text` platforms provide REST-backed entities (free-charging toggle and tag ID).
+- `rest_client.py` – `RestClient` for optional REST API communication. Handles JWT authentication, token refresh, and API calls for features not available via Modbus; uses Home Assistant's shared aiohttp session.
+- `coordinator.py` – `DataUpdateCoordinator` implementation that schedules read cycles, normalises raw register values, optionally fetches REST API data, and emits the dispatcher-based device triggers when relevant state changes are detected. On REST `401` it starts the reauth flow via `config_entry.async_start_reauth`.
+- `config_flow.py` – User, options, **reconfigure** and **reauth** flows with validation and duplicate protection. Includes optional REST API credential configuration.
+- `device_trigger.py` – Device-trigger registry and helpers used by `coordinator.py` to fire triggers (`async_fire_device_trigger`) for charging / connection / cable / fault events.
+- `diagnostics.py` – Config-entry diagnostics download (REST username and password are redacted).
+- Platform modules (`sensor.py`, `number.py`, `button.py`, `switch.py`, `binary_sensor.py`, `text.py`) – Entity classes backed by static descriptions. `binary_sensor.py` exposes the always-available **Connected** sensor and a **Charging** sensor (`device_class: battery_charging`); the `switch`/`text` platforms provide REST-backed entities (free-charging toggle and tag ID) plus the Unite-only three-phase switch.
 - `services.yaml` – Service schemas surfaced to Home Assistant.
+- `icons.json` – Entity icons (icon-translations rule).
+- `quality_scale.yaml` – Per-rule status for the HA integration quality scale (Platinum).
+- `translations/en.json`, `translations/de.json` – Entity, state, exception, device-trigger, config-flow and options-flow translations.
 
 ## Data flow
 
@@ -117,7 +137,10 @@ The register ranges are derived from community research and vendor documentation
 ## Assumptions and open items
 
 - Defaults assume TCP port `502` and unit ID `255`; both are user-configurable during onboarding.
-- Firmware revisions prior to `3.1` may omit the keep-alive register; the integration degrades gracefully by hiding the button.
+- The wallbox accepts a **single** Modbus TCP client at a time; the integration owns that slot for the lifetime of the config entry. A booting wallbox or a stale socket from another client therefore manifests as transient connection errors that are retried automatically.
+- Registers a given firmware doesn't implement are handled automatically: optional blocks are dropped from the read plan after the first error response, and the corresponding entities become unavailable rather than spamming warnings.
+- The Unite three-phase switch (holding register `405`) is undocumented in the vendor Modbus spec and confirmed on firmware 3.187 ([#37](https://github.com/tomwellnitz/Webasto-Next-Modbus/issues/37)); on other Unite firmwares the behaviour is unverified.
+- The wallbox web interface uses a self-signed TLS certificate, so the REST client is built on `async_get_clientsession(hass, verify_ssl=False)`.
 
 ## Future enhancements
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -28,10 +28,9 @@
 | **"It's broken!"** | [GitHub Issues](https://github.com/tomwellnitz/Webasto-Next-Modbus/issues) (Please attach diagnostics!) |
 | **"I have an idea!"** | [Feature Requests](https://github.com/tomwellnitz/Webasto-Next-Modbus/issues) |
 
-## Known Limitations
+## Known limitations
 
-- **Dynamic IP**: The integration expects a static IP. Please configure a DHCP reservation for your wallbox.
-- **Old Firmware**: Firmware < 3.1 might not support all features (like Keepalive).
+See the [Known limitations](../README.md#known-limitations) section in the README for the verified, up-to-date list (single Modbus client at a time, Modbus off by default, no auto-discovery, REST self-signed certificate, Unite three-phase switching firmware-dependent, …).
 
 ## Security
 


### PR DESCRIPTION
## Summary

Audit of the user and architecture docs against the HA quality scale Gold/Platinum doc rules surfaced four real gaps and one outdated statement. This PR closes them.

### Gaps closed (all sourced, no maintainer guesses)

- **`docs-data-update`** — README had no polling-interval information. New **Data updates** section documents Modbus (10 s, configurable), REST (60 s), REST setup retry (5 min) and the Life Bit cadence, sourced from `const.py`.
- **`docs-known-limitations`** — limitations were scattered across the troubleshooting section and `docs/support.md`. Consolidated into a single **Known limitations** section in the README. Each item traces to evidence (issue, code, or release note); see commit message for the per-item sources. The unverified "Firmware < 3.1 lacks keep-alive" maintainer assumption was **removed** from both `architecture.md` and `support.md`.
- **`docs-examples`** — README only listed blueprints. Added a copy-paste-ready custom YAML example covering a service action (`set_current` with the **verified** `amps` parameter) and a device trigger (`fault_occurred` using the actual `trigger.event.data.fault_code` payload from `coordinator.py`).
- **`docs-configuration-parameters`** — the **Model** selector (Next vs Unite) was missing from the Configuration list and the *Reconfigure* / *Configure* entry points weren't mentioned. Both added.

### Stale content fixed

- README line 86 still said *"a repair issue is raised"* when REST credentials are rejected — but 1.3.0 replaced that with the reauth flow. Now describes the actual behaviour.
- The Event-notifications blueprint description was missing the `cable_connected` / `cable_disconnected` / `fault_occurred` triggers added in 1.3.0.
- `docs/architecture.md` was a pre-1.3.0 snapshot. Updated functional-requirements and software-components lists to include reconfigure & reauth flows, `device_trigger.py`, `diagnostics.py`, `icons.json`, `quality_scale.yaml`, translations, the Charging binary sensor, the Unite-only three-phase switch, and the Platinum-tier rules.
- New short subsection in `architecture.md` documenting the **Unite vs Next register differences** (input vs holding telemetry block, 32-bit energy in 0.1 kWh, Unite-only registers `400` / `404` / `405` / `1014`-`1018`) — all from the community readouts in #37.
- `docs/support.md` "Known Limitations" deferred to the README (single source of truth).

CHANGELOG `[Unreleased]` entry added. Doc-only change, no version bump.

## Test plan

- [ ] CI green (ruff/codespell/yamllint/mypy/hassfest/pytest)
- [ ] Manual: README renders correctly on GitHub; new section anchors (`#data-updates`, `#known-limitations`) resolve; YAML example is valid (replace `<your wallbox device id>`)

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_