### PR TITLE
ci: fix upstream-compat version-print step (uv venv has no pip)

### DIFF
--- a/.github/workflows/upstream-compat.yml
+++ b/.github/workflows/upstream-compat.yml
@@ -47,12 +47,16 @@ jobs:
             packaging
 
       - name: Show installed versions
+        # `uv venv` intentionally creates a venv without pip (uv itself is
+        # the package manager). Read the installed version from the metadata
+        # instead of shelling out to `python -m pip show`.
         run: |
           source .venv-canary/bin/activate
-          echo "=== Home Assistant ==="
-          python -m pip show homeassistant | grep -E "^(Name|Version):"
-          echo "=== pymodbus ==="
-          python -m pip show pymodbus | grep -E "^(Name|Version):"
+          python - <<'PY'
+          from importlib.metadata import version
+          print(f"Home Assistant : {version('homeassistant')}")
+          print(f"pymodbus       : {version('pymodbus')}")
+          PY
 
       - name: Verify manifest requirements are satisfied
         run: |


### PR DESCRIPTION
## Summary

Follow-up to #91: the very first manual run of the new `Upstream compatibility` canary went red (https://github.com/tomwellnitz/Webasto-Next-Modbus/actions/runs/28609837406) — but on **its own diagnostic step**, not on the substance.

The install step succeeded cleanly (log confirms `homeassistant==2026.7.0` and `pymodbus==3.13.1` both installed alongside each other). The next step then failed with:

```
=== Home Assistant ===
/home/runner/.../.venv-canary/bin/python: No module named pip
##[error]Process completed with exit code 1.
```

Root cause: `uv venv` intentionally creates a virtual environment **without** `pip` (uv is itself the package manager). My step reached for `python -m pip show ...` instead. The real checks — manifest requirement, smoke import, hassfest — never got a chance to run.

## Fix

Read installed versions via `importlib.metadata` instead. That works from any venv (with or without pip installed) and is idiomatic Python:

```python
from importlib.metadata import version
print(f"Home Assistant : {version('homeassistant')}")
print(f"pymodbus       : {version('pymodbus')}")
```

Inline comment added explaining the uv-venv quirk so a future reader doesn't reintroduce `pip show`.

## Test plan

- [ ] CI on this PR green.
- [ ] After merge: manually trigger `Actions → Upstream compatibility → Run workflow` on `main`; it should install HA + pymodbus, print both versions via metadata, pass the manifest requirement check (`pymodbus>=3.11.2` with `pymodbus==3.13.1` installed → ✓), pass the smoke import of `const` / `hub` / `rest_client` / `coordinator` / `device_trigger`, and pass hassfest.

https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_