### PR TITLE
feat: model-aware REST client with Unite REST support (#97)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Check spelling with codespell
         run: |
-          uv run codespell --ignore-words-list=hass,alot,datas,dof,dur,farenheit,hist,iff,ines,ist,lights,mut,nd,pres,provid,referance,ser,serie,te,technik,ue,uint,visability,wan,wanna,withing,iam,incomfort,ba,sould,startet,oder,stopp,alle,unter,adresse --skip="./.*,*.csv,*.json,*.ambr,*.pdf,uv.lock" --quiet-level=2
+          uv run codespell --ignore-words-list=hass,alot,datas,dof,dur,farenheit,hist,iff,ines,ist,lights,mut,nd,pres,provid,referance,ser,serie,te,technik,ue,uint,visability,wan,wanna,withing,iam,incomfort,ba,sould,startet,oder,stopp,alle,unter,adresse,randomised --skip="./.*,*.csv,*.json,*.ambr,*.pdf,uv.lock" --quiet-level=2
 
       - name: Lint YAML with yamllint
         run: |

--- a/.vulture_whitelist.py
+++ b/.vulture_whitelist.py
@@ -33,3 +33,4 @@ _attr_state_class  # unused attribute
 _attr_options  # unused attribute
 _attr_translation_key  # unused attribute
 use_as_default  # unused arg required by pymodbus' ModbusSlaveContext.setValues signature
+async_select_option  # unused method required by Home Assistant's SelectEntity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- **REST API support for the Ampure / Webasto Unite** ([#97](https://github.com/tomwellnitz/Webasto-Next-Modbus/issues/97), thanks @lonkhuijzen for the reverse-engineering). The Unite serves a different REST surface than the Next — a single flat `/api/configuration-fields/` endpoint with its own field keys and a single update type — so the REST client is now model-aware. On a Unite, enabling the REST API exposes the **Free charging** switch and **tag ID**, a new **LED dimming level** select (`veryLow`/`low`/`mid`/`high`/`timeBased`, since the Unite has no 0-100 brightness), and a **Randomised start delay** number (0-1800 s). The Next's firmware/diagnostic REST sensors have no Unite equivalent (that data isn't in the Unite's REST API) and are not created on a Unite; live telemetry is unaffected — it comes over Modbus.
 - **`.github/workflows/upstream-compat.yml`** — early-warning canary against the moving targets HA-Core ships. Runs weekly (and on demand) against the latest Home Assistant and pymodbus releases, verifies the manifest requirement is still satisfied, smoke-imports the production modules, and re-runs hassfest. A red run signals that an upcoming HA release will break the integration ~1-2 weeks before end users hit it.
 
 ## [1.3.1] - 2026-07-02

--- a/custom_components/webasto_next_modbus/__init__.py
+++ b/custom_components/webasto_next_modbus/__init__.py
@@ -74,6 +74,7 @@ PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.BUTTON,
     Platform.SWITCH,
+    Platform.SELECT,
     Platform.TEXT,
 ]
 
@@ -184,6 +185,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: WebastoConfigEntry) -> b
         device_slug,
         config_entry=entry,
         device_model_name=get_model_display_name(model),
+        model=model,
     )
 
     try:

--- a/custom_components/webasto_next_modbus/const.py
+++ b/custom_components/webasto_next_modbus/const.py
@@ -29,6 +29,12 @@ DEFAULT_REST_USERNAME: Final = "admin"
 REST_SCAN_INTERVAL: Final = 60  # REST API polling interval (seconds)
 REST_SETUP_RETRY_INTERVAL: Final = 300  # retry a failed REST connect this often (seconds)
 
+# Webasto / Ampure Unite REST settings (served via the flat
+# `/api/configuration-fields/` endpoint; see issue #97). The LED dimming level
+# is an enum on the Unite rather than the Next's 0-100 brightness.
+UNITE_LED_DIMMING_LEVELS: Final = ("veryLow", "low", "mid", "high", "timeBased")
+UNITE_RANDOMISED_DELAY_MAX: Final = 1800  # seconds
+
 VARIANT_11_KW: Final = "11kw"
 VARIANT_22_KW: Final = "22kw"
 DEFAULT_VARIANT: Final = VARIANT_22_KW

--- a/custom_components/webasto_next_modbus/const.py
+++ b/custom_components/webasto_next_modbus/const.py
@@ -33,6 +33,19 @@ REST_SETUP_RETRY_INTERVAL: Final = 300  # retry a failed REST connect this often
 # `/api/configuration-fields/` endpoint; see issue #97). The LED dimming level
 # is an enum on the Unite rather than the Next's 0-100 brightness.
 UNITE_LED_DIMMING_LEVELS: Final = ("veryLow", "low", "mid", "high", "timeBased")
+# Home Assistant select options and translation keys must be lowercase slugs,
+# but the wallbox API values are camelCase. Map the HA-facing option to the API
+# value; the select entity translates in both directions.
+UNITE_LED_DIMMING_OPTION_TO_API: Final = {
+    "very_low": "veryLow",
+    "low": "low",
+    "mid": "mid",
+    "high": "high",
+    "time_based": "timeBased",
+}
+UNITE_LED_DIMMING_API_TO_OPTION: Final = {
+    api: option for option, api in UNITE_LED_DIMMING_OPTION_TO_API.items()
+}
 UNITE_RANDOMISED_DELAY_MAX: Final = 1800  # seconds
 
 VARIANT_11_KW: Final = "11kw"

--- a/custom_components/webasto_next_modbus/coordinator.py
+++ b/custom_components/webasto_next_modbus/coordinator.py
@@ -22,6 +22,7 @@ from .const import (
     FAILURE_NOTIFICATION_THRESHOLD,
     FAILURE_NOTIFICATION_TITLE,
     MODEL,
+    MODEL_NEXT,
     REST_SCAN_INTERVAL,
     REST_SETUP_RETRY_INTERVAL,
 )
@@ -55,10 +56,12 @@ class WebastoDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         device_slug: str,
         config_entry: ConfigEntry | None = None,
         device_model_name: str = MODEL,
+        model: str = MODEL_NEXT,
     ) -> None:
         self._bridge = bridge
         self._device_slug = device_slug
         self.device_model_name = device_model_name
+        self._model = model
         self.entry_id = entry_id
         self.consecutive_failures = 0
         self.last_success: datetime | None = None
@@ -109,7 +112,7 @@ class WebastoDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Use Home Assistant's shared aiohttp session. The wallbox has a
         # self-signed certificate, so SSL verification must be disabled.
         session = async_get_clientsession(self.hass, verify_ssl=False)
-        self._rest_client = RestClient(host, username, password, session)
+        self._rest_client = RestClient(host, username, password, session, model=self._model)
 
         try:
             await self._rest_client.connect()

--- a/custom_components/webasto_next_modbus/icons.json
+++ b/custom_components/webasto_next_modbus/icons.json
@@ -116,6 +116,9 @@
       },
       "set_current_a": {
         "default": "mdi:speedometer"
+      },
+      "randomised_delay": {
+        "default": "mdi:timer-sand"
       }
     },
     "button": {
@@ -138,6 +141,11 @@
       },
       "phase_switch": {
         "default": "mdi:transmission-tower"
+      }
+    },
+    "select": {
+      "led_dimming": {
+        "default": "mdi:brightness-6"
       }
     }
   }

--- a/custom_components/webasto_next_modbus/manifest.json
+++ b/custom_components/webasto_next_modbus/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "pymodbus>=3.11.2"
   ],
-  "version": "1.3.1"
+  "version": "1.4.0"
 }

--- a/custom_components/webasto_next_modbus/number.py
+++ b/custom_components/webasto_next_modbus/number.py
@@ -11,7 +11,7 @@ from homeassistant.components.number import (
     NumberMode,
     RestoreNumber,
 )
-from homeassistant.const import CONF_HOST, PERCENTAGE, EntityCategory
+from homeassistant.const import CONF_HOST, PERCENTAGE, EntityCategory, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -21,7 +21,10 @@ from . import WebastoConfigEntry
 from .const import (
     CONF_UNIT_ID,
     DOMAIN,
+    MODEL_NEXT,
+    MODEL_UNITE,
     SIGNAL_REGISTER_WRITTEN,
+    UNITE_RANDOMISED_DELAY_MAX,
     RegisterDefinition,
     get_number_registers,
 )
@@ -61,16 +64,28 @@ async def async_setup_entry(
         for register in get_number_registers(runtime.model)
     ]
 
-    # Add LED brightness if REST API is enabled
+    # REST-backed number entities are model-specific: the Next exposes a 0-100
+    # LED brightness; the Unite has no such field but exposes a randomised
+    # start-delay (its LED control is an enum, handled by the select platform).
     if runtime.coordinator.rest_enabled:
-        entities.append(
-            WebastoLedBrightness(
-                runtime.coordinator,
-                host,
-                unit_id,
-                runtime.device_name,
+        if runtime.model == MODEL_NEXT:
+            entities.append(
+                WebastoLedBrightness(
+                    runtime.coordinator,
+                    host,
+                    unit_id,
+                    runtime.device_name,
+                )
             )
-        )
+        elif runtime.model == MODEL_UNITE:
+            entities.append(
+                WebastoRandomisedDelay(
+                    runtime.coordinator,
+                    host,
+                    unit_id,
+                    runtime.device_name,
+                )
+            )
 
     async_add_entities(entities)
 
@@ -342,4 +357,78 @@ class WebastoLedBrightness(WebastoRestEntity, NumberEntity):
 
         # Re-fetch the REST data now (regular polling is throttled) so the UI
         # shows the value the wallbox actually has.
+        await self.coordinator.async_refresh_rest_data()
+
+
+class WebastoRandomisedDelay(WebastoRestEntity, NumberEntity):
+    """Number entity for the Unite's randomised start delay via REST API.
+
+    ``0`` disables the delay; otherwise the wallbox waits up to the configured
+    number of seconds before starting a charge (grid-friendly load spreading).
+    """
+
+    _attr_has_entity_name = True
+    _attr_mode = NumberMode.BOX
+    _attr_native_min_value = 0
+    _attr_native_max_value = UNITE_RANDOMISED_DELAY_MAX
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: WebastoDataCoordinator,
+        host: str,
+        unit_id: int,
+        device_name: str,
+    ) -> None:
+        super().__init__(
+            coordinator, host, unit_id, "randomised_delay", device_name, coordinator.rest_client
+        )
+        self._pending_value: int | None = None
+
+    def _handle_coordinator_update(self) -> None:
+        """Update the native value from coordinator REST data."""
+
+        rest_data = self.coordinator.rest_data
+        current = (
+            None
+            if rest_data is None or rest_data.randomised_delay is None
+            else int(rest_data.randomised_delay)
+        )
+        if self._pending_value is not None and current == self._pending_value:
+            self._pending_value = None
+
+        if self._pending_value is not None:
+            self._attr_native_value = float(self._pending_value)
+        else:
+            self._attr_native_value = None if current is None else float(current)
+
+        super()._handle_coordinator_update()
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the randomised delay via REST API."""
+        if self._rest_client is None:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="rest_not_connected"
+            )
+
+        int_value = int(round(value))
+        self._pending_value = int_value
+        self._attr_native_value = float(int_value)
+        if self.hass is not None:
+            self.async_write_ha_state()
+
+        try:
+            await self._rest_client.set_randomised_delay(int_value)
+        except Exception as err:
+            self._pending_value = None
+            if self.hass is not None:
+                self._handle_coordinator_update()
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_randomised_delay_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
+
         await self.coordinator.async_refresh_rest_data()

--- a/custom_components/webasto_next_modbus/rest_client.py
+++ b/custom_components/webasto_next_modbus/rest_client.py
@@ -94,14 +94,15 @@ class RestData:
 
 
 class RestClient:
-    """Async REST API client for Webasto Next wallbox.
+    """Async REST API client for Webasto Next / Ampure Unite wallboxes.
 
-    This client provides access to features not available via Modbus:
-    - LED brightness control
-    - Firmware/hardware versions
-    - MAC addresses and network info
-    - Diagnostic counters (plug cycles, errors)
-    - System restart
+    Provides access to features not available via Modbus. The two models expose
+    different REST surfaces, so the client is model-aware:
+
+    - Next: per-section endpoints — firmware/hardware versions, MAC/network
+      info, diagnostic counters, LED brightness, free charging, restart.
+    - Unite: a single flat ``configuration-fields`` endpoint — free charging,
+      LED dimming level, randomised start delay, restart (no diagnostic data).
     """
 
     def __init__(
@@ -266,8 +267,11 @@ class RestClient:
 
         Raises:
             ValueError: If the level is unknown.
-            RestClientError: If the request fails.
+            RestClientError: If called on a non-Unite model or the request fails.
         """
+        if not self._is_unite:
+            msg = "LED dimming level is only available on the Unite"
+            raise RestClientError(msg)
         if level not in UNITE_LED_DIMMING_LEVELS:
             msg = f"Unknown LED dimming level {level!r}"
             raise ValueError(msg)
@@ -283,8 +287,11 @@ class RestClient:
 
         Raises:
             ValueError: If the value is out of range.
-            RestClientError: If the request fails.
+            RestClientError: If called on a non-Unite model or the request fails.
         """
+        if not self._is_unite:
+            msg = "Randomised delay is only available on the Unite"
+            raise RestClientError(msg)
         if not 0 <= seconds <= UNITE_RANDOMISED_DELAY_MAX:
             msg = f"Randomised delay must be 0-{UNITE_RANDOMISED_DELAY_MAX}, got {seconds}"
             raise ValueError(msg)
@@ -555,12 +562,22 @@ class RestClient:
 
     @staticmethod
     def _parse_bool(value: Any) -> bool | None:
-        """Parse the Unite's boolean fields (returned as "TRUE"/"FALSE" strings)."""
+        """Parse the Unite's boolean fields (returned as "TRUE"/"FALSE" strings).
+
+        Returns None for unrecognised values rather than silently treating them
+        as False, so an unexpected API value surfaces as "unknown" instead of a
+        wrong state.
+        """
         if value is None:
             return None
         if isinstance(value, bool):
             return value
-        return str(value).strip().lower() in ("true", "1", "on", "yes")
+        text = str(value).strip().lower()
+        if text in ("true", "1", "on", "yes"):
+            return True
+        if text in ("false", "0", "off", "no"):
+            return False
+        return None
 
     def _parse_system_fields(self, fields: list[dict[str, Any]], values: dict[str, Any]) -> None:
         """Parse system section fields into values dict."""

--- a/custom_components/webasto_next_modbus/rest_client.py
+++ b/custom_components/webasto_next_modbus/rest_client.py
@@ -10,10 +10,21 @@ from typing import TYPE_CHECKING, Any, Final
 
 import aiohttp
 
+from .const import (
+    MODEL_NEXT,
+    MODEL_UNITE,
+    UNITE_LED_DIMMING_LEVELS,
+    UNITE_RANDOMISED_DELAY_MAX,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
 _LOGGER = logging.getLogger(__name__)
+
+# Unite writes go through a single update type for every field, unlike the
+# Next's per-type values (see issue #97).
+_UNITE_UPDATE_TYPE: Final = "simple-configuration-field-update"
 
 # API Configuration
 DEFAULT_TIMEOUT: Final = 30
@@ -77,6 +88,10 @@ class RestData:
     signal_voltage_l3: float | None = None
     active_errors: list[str] | None = None
 
+    # Unite-only settings (served via /api/configuration-fields/)
+    led_dimming_level: str | None = None
+    randomised_delay: int | None = None
+
 
 class RestClient:
     """Async REST API client for Webasto Next wallbox.
@@ -97,6 +112,7 @@ class RestClient:
         session: aiohttp.ClientSession,
         *,
         timeout: int = DEFAULT_TIMEOUT,
+        model: str = MODEL_NEXT,
     ) -> None:
         """Initialize the REST client.
 
@@ -110,16 +126,25 @@ class RestClient:
                 must be disabled by the caller. The session is owned by Home
                 Assistant and must not be closed here.
             timeout: Request timeout in seconds.
+            model: Wallbox model (``MODEL_NEXT`` or ``MODEL_UNITE``). The Unite
+                serves a different REST surface (flat configuration-fields
+                endpoint, different field keys and a single update type).
         """
         self._host = host
         self._username = username
         self._password = password
         self._base_url = f"https://{host}/api"
+        self._model = model
 
         self._session = session
         self._request_timeout = aiohttp.ClientTimeout(total=timeout)
         self._token: str | None = None
         self._token_expires: datetime | None = None
+
+    @property
+    def _is_unite(self) -> bool:
+        """Return True if this client targets a Webasto / Ampure Unite."""
+        return self._model == MODEL_UNITE
 
     @property
     def is_connected(self) -> bool:
@@ -156,7 +181,12 @@ class RestClient:
             RestClientError: If fetching data fails.
         """
         await self._ensure_token()
+        if self._is_unite:
+            return await self._get_data_unite()
+        return await self._get_data_next()
 
+    async def _get_data_next(self) -> RestData:
+        """Fetch REST data for the Webasto Next (per-section endpoints)."""
         values: dict[str, Any] = {}
 
         # Fetch system section
@@ -182,6 +212,21 @@ class RestClient:
 
         return RestData(**values)
 
+    async def _get_data_unite(self) -> RestData:
+        """Fetch REST data for the Unite (flat configuration-fields endpoint).
+
+        The Unite has no equivalent for the Next's firmware / diagnostic
+        sensors — its REST surface is configuration only — so only the mappable
+        settings (free charging, LED dimming, randomised delay) are returned.
+        """
+        values: dict[str, Any] = {}
+        try:
+            fields = await self._get_configuration_fields()
+            self._parse_unite_fields(fields, values)
+        except Exception as err:
+            _LOGGER.debug("Failed to fetch Unite configuration fields: %r", err)
+        return RestData(**values)
+
     async def set_led_brightness(self, brightness: int) -> None:
         """Set LED brightness.
 
@@ -192,6 +237,12 @@ class RestClient:
             ValueError: If brightness is out of range.
             RestClientError: If the request fails.
         """
+        if self._is_unite:
+            # The Unite has no 0-100 brightness field; it uses an enum dimming
+            # level instead (see set_led_dimming_level).
+            msg = "LED brightness is not available on the Unite; use LED dimming level"
+            raise RestClientError(msg)
+
         if not 0 <= brightness <= 100:
             msg = f"Brightness must be 0-100, got {brightness}"
             raise ValueError(msg)
@@ -207,6 +258,42 @@ class RestClient:
             ]
         )
 
+    async def set_led_dimming_level(self, level: str) -> None:
+        """Set the LED dimming level (Unite only).
+
+        Args:
+            level: One of ``UNITE_LED_DIMMING_LEVELS``.
+
+        Raises:
+            ValueError: If the level is unknown.
+            RestClientError: If the request fails.
+        """
+        if level not in UNITE_LED_DIMMING_LEVELS:
+            msg = f"Unknown LED dimming level {level!r}"
+            raise ValueError(msg)
+
+        await self._ensure_token()
+        await self._update_config([self._unite_update("generalSettings.ledDimmingLevel", level)])
+
+    async def set_randomised_delay(self, seconds: int) -> None:
+        """Set the randomised charging-start delay in seconds (Unite only).
+
+        Args:
+            seconds: 0 (disabled) to ``UNITE_RANDOMISED_DELAY_MAX``.
+
+        Raises:
+            ValueError: If the value is out of range.
+            RestClientError: If the request fails.
+        """
+        if not 0 <= seconds <= UNITE_RANDOMISED_DELAY_MAX:
+            msg = f"Randomised delay must be 0-{UNITE_RANDOMISED_DELAY_MAX}, got {seconds}"
+            raise ValueError(msg)
+
+        await self._ensure_token()
+        await self._update_config(
+            [self._unite_update("generalSettings.randomisedDelayMaximumDuration", str(seconds))]
+        )
+
     async def set_free_charging(self, enabled: bool) -> None:
         """Enable or disable free charging mode.
 
@@ -217,6 +304,15 @@ class RestClient:
             RestClientError: If the request fails.
         """
         await self._ensure_token()
+        if self._is_unite:
+            await self._update_config(
+                [
+                    self._unite_update(
+                        "ocppConfigurations.freeModeActive", "TRUE" if enabled else "FALSE"
+                    )
+                ]
+            )
+            return
         await self._update_config(
             [
                 {
@@ -237,6 +333,11 @@ class RestClient:
             RestClientError: If the request fails.
         """
         await self._ensure_token()
+        if self._is_unite:
+            await self._update_config(
+                [self._unite_update("ocppConfigurations.freeModeRfid", tag_id)]
+            )
+            return
         await self._update_config(
             [
                 {
@@ -246,6 +347,15 @@ class RestClient:
                 }
             ]
         )
+
+    @staticmethod
+    def _unite_update(field_key: str, value: str) -> dict[str, Any]:
+        """Build a Unite configuration-update payload entry."""
+        return {
+            "fieldKey": field_key,
+            "value": value,
+            "configurationFieldUpdateType": _UNITE_UPDATE_TYPE,
+        }
 
     async def restart_system(self) -> None:
         """Trigger a system restart.
@@ -417,9 +527,40 @@ class RestClient:
                 errors.append(str(error))
         return errors
 
+    async def _get_configuration_fields(self) -> list[dict[str, Any]]:
+        """Get the Unite's flat list of configuration fields."""
+        result = await self._get("/configuration-fields/")
+        if not isinstance(result, list):
+            return []
+        return result
+
     async def _update_config(self, updates: list[dict[str, Any]]) -> None:
         """Update configuration fields."""
         await self._post("/configuration-updates", json=updates)
+
+    def _parse_unite_fields(self, fields: list[dict[str, Any]], values: dict[str, Any]) -> None:
+        """Parse the Unite's flat configuration fields into values dict."""
+        for field in fields:
+            key = field.get("fieldKey", "")
+            value = field.get("value")
+
+            if key == "ocppConfigurations.freeModeActive":
+                values["free_charging_enabled"] = self._parse_bool(value)
+            elif key == "ocppConfigurations.freeModeRfid":
+                values["free_charging_tag_id"] = value
+            elif key == "generalSettings.ledDimmingLevel":
+                values["led_dimming_level"] = value if value in UNITE_LED_DIMMING_LEVELS else None
+            elif key == "generalSettings.randomisedDelayMaximumDuration":
+                values["randomised_delay"] = self._safe_int(value)
+
+    @staticmethod
+    def _parse_bool(value: Any) -> bool | None:
+        """Parse the Unite's boolean fields (returned as "TRUE"/"FALSE" strings)."""
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return value
+        return str(value).strip().lower() in ("true", "1", "on", "yes")
 
     def _parse_system_fields(self, fields: list[dict[str, Any]], values: dict[str, Any]) -> None:
         """Parse system section fields into values dict."""

--- a/custom_components/webasto_next_modbus/select.py
+++ b/custom_components/webasto_next_modbus/select.py
@@ -1,0 +1,107 @@
+"""Select platform for Webasto Next Modbus integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.const import CONF_HOST, EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import WebastoConfigEntry
+from .const import CONF_UNIT_ID, DOMAIN, MODEL_UNITE, UNITE_LED_DIMMING_LEVELS
+from .coordinator import WebastoDataCoordinator
+from .entity import WebastoRestEntity
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: WebastoConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Webasto select entities."""
+    runtime = entry.runtime_data
+
+    host = entry.data[CONF_HOST]
+    unit_id = entry.data[CONF_UNIT_ID]
+
+    entities: list[SelectEntity] = []
+
+    # The Unite's LED dimming level is an enum via REST (the Next uses a 0-100
+    # brightness number instead, handled by the number platform).
+    if runtime.coordinator.rest_enabled and runtime.model == MODEL_UNITE:
+        entities.append(
+            WebastoLedDimming(
+                runtime.coordinator,
+                host,
+                unit_id,
+                runtime.device_name,
+            )
+        )
+
+    async_add_entities(entities)
+
+
+class WebastoLedDimming(WebastoRestEntity, SelectEntity):
+    """Select entity for the Unite's LED dimming level via REST API."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_options = list(UNITE_LED_DIMMING_LEVELS)
+
+    def __init__(
+        self,
+        coordinator: WebastoDataCoordinator,
+        host: str,
+        unit_id: int,
+        device_name: str,
+    ) -> None:
+        super().__init__(
+            coordinator, host, unit_id, "led_dimming", device_name, coordinator.rest_client
+        )
+        self._pending_option: str | None = None
+
+    def _handle_coordinator_update(self) -> None:
+        """Update the current option from coordinator REST data."""
+
+        rest_data = self.coordinator.rest_data
+        current = None if rest_data is None else rest_data.led_dimming_level
+        # Drop the optimistic value once the wallbox confirms it via REST.
+        if self._pending_option is not None and current == self._pending_option:
+            self._pending_option = None
+
+        if self._pending_option is not None:
+            self._attr_current_option = self._pending_option
+        else:
+            self._attr_current_option = current
+        super()._handle_coordinator_update()
+
+    async def async_select_option(self, option: str) -> None:
+        """Set the LED dimming level via REST API."""
+        if self._rest_client is None:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="rest_not_connected"
+            )
+
+        self._pending_option = option
+        self._attr_current_option = option
+        if self.hass is not None:
+            self.async_write_ha_state()
+
+        try:
+            await self._rest_client.set_led_dimming_level(option)
+        except Exception as err:
+            self._pending_option = None
+            if self.hass is not None:
+                self._handle_coordinator_update()
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_led_dimming_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
+
+        # Re-fetch the REST data now (regular polling is throttled) so the UI
+        # shows the level the wallbox actually has.
+        await self.coordinator.async_refresh_rest_data()

--- a/custom_components/webasto_next_modbus/select.py
+++ b/custom_components/webasto_next_modbus/select.py
@@ -9,7 +9,13 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import WebastoConfigEntry
-from .const import CONF_UNIT_ID, DOMAIN, MODEL_UNITE, UNITE_LED_DIMMING_LEVELS
+from .const import (
+    CONF_UNIT_ID,
+    DOMAIN,
+    MODEL_UNITE,
+    UNITE_LED_DIMMING_API_TO_OPTION,
+    UNITE_LED_DIMMING_OPTION_TO_API,
+)
 from .coordinator import WebastoDataCoordinator
 from .entity import WebastoRestEntity
 
@@ -49,7 +55,9 @@ class WebastoLedDimming(WebastoRestEntity, SelectEntity):
 
     _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_options = list(UNITE_LED_DIMMING_LEVELS)
+    # HA-facing options are lowercase slugs (translation keys must be); the
+    # wallbox's camelCase API values are mapped in/out below.
+    _attr_options = list(UNITE_LED_DIMMING_OPTION_TO_API)
 
     def __init__(
         self,
@@ -67,7 +75,8 @@ class WebastoLedDimming(WebastoRestEntity, SelectEntity):
         """Update the current option from coordinator REST data."""
 
         rest_data = self.coordinator.rest_data
-        current = None if rest_data is None else rest_data.led_dimming_level
+        api_value = None if rest_data is None else rest_data.led_dimming_level
+        current = UNITE_LED_DIMMING_API_TO_OPTION.get(api_value) if api_value else None
         # Drop the optimistic value once the wallbox confirms it via REST.
         if self._pending_option is not None and current == self._pending_option:
             self._pending_option = None
@@ -91,7 +100,7 @@ class WebastoLedDimming(WebastoRestEntity, SelectEntity):
             self.async_write_ha_state()
 
         try:
-            await self._rest_client.set_led_dimming_level(option)
+            await self._rest_client.set_led_dimming_level(UNITE_LED_DIMMING_OPTION_TO_API[option])
         except Exception as err:
             self._pending_option = None
             if self.hass is not None:

--- a/custom_components/webasto_next_modbus/translations/de.json
+++ b/custom_components/webasto_next_modbus/translations/de.json
@@ -277,11 +277,11 @@
       "led_dimming": {
         "name": "LED-Dimmstufe",
         "state": {
-          "veryLow": "Sehr niedrig",
+          "very_low": "Sehr niedrig",
           "low": "Niedrig",
           "mid": "Mittel",
           "high": "Hoch",
-          "timeBased": "Zeitbasiert"
+          "time_based": "Zeitbasiert"
         }
       }
     }

--- a/custom_components/webasto_next_modbus/translations/de.json
+++ b/custom_components/webasto_next_modbus/translations/de.json
@@ -241,6 +241,9 @@
       },
       "led_brightness": {
         "name": "LED Helligkeit"
+      },
+      "randomised_delay": {
+        "name": "Zufällige Startverzögerung"
       }
     },
     "button": {
@@ -268,6 +271,18 @@
       },
       "phase_switch": {
         "name": "Dreiphasiges Laden"
+      }
+    },
+    "select": {
+      "led_dimming": {
+        "name": "LED-Dimmstufe",
+        "state": {
+          "veryLow": "Sehr niedrig",
+          "low": "Niedrig",
+          "mid": "Mittel",
+          "high": "Hoch",
+          "timeBased": "Zeitbasiert"
+        }
       }
     }
   },
@@ -331,6 +346,12 @@
     },
     "restart_failed": {
       "message": "Neustart der Wallbox fehlgeschlagen: {error}"
+    },
+    "set_led_dimming_failed": {
+      "message": "LED-Dimmstufe konnte nicht gesetzt werden: {error}"
+    },
+    "set_randomised_delay_failed": {
+      "message": "Zufällige Startverzögerung konnte nicht gesetzt werden: {error}"
     }
   },
   "device_automation": {

--- a/custom_components/webasto_next_modbus/translations/en.json
+++ b/custom_components/webasto_next_modbus/translations/en.json
@@ -156,7 +156,8 @@
           "pwr_internal_error": "Internal power error",
           "ev_communication_error_negative_pilot": "EV communication error (negative pilot)",
           "dc_residual_current_error": "DC residual current error"
-        }      },
+        }
+      },
       "current_l1_a": {
         "name": "Current L1"
       },
@@ -275,6 +276,9 @@
       },
       "led_brightness": {
         "name": "LED Brightness"
+      },
+      "randomised_delay": {
+        "name": "Randomised start delay"
       }
     },
     "button": {
@@ -297,6 +301,18 @@
       },
       "phase_switch": {
         "name": "Three-phase charging"
+      }
+    },
+    "select": {
+      "led_dimming": {
+        "name": "LED dimming level",
+        "state": {
+          "veryLow": "Very low",
+          "low": "Low",
+          "mid": "Medium",
+          "high": "High",
+          "timeBased": "Time based"
+        }
       }
     }
   },
@@ -330,6 +346,12 @@
     },
     "restart_failed": {
       "message": "Failed to restart the wallbox: {error}"
+    },
+    "set_led_dimming_failed": {
+      "message": "Failed to set LED dimming level: {error}"
+    },
+    "set_randomised_delay_failed": {
+      "message": "Failed to set randomised delay: {error}"
     }
   },
   "device_automation": {

--- a/custom_components/webasto_next_modbus/translations/en.json
+++ b/custom_components/webasto_next_modbus/translations/en.json
@@ -307,11 +307,11 @@
       "led_dimming": {
         "name": "LED dimming level",
         "state": {
-          "veryLow": "Very low",
+          "very_low": "Very low",
           "low": "Low",
           "mid": "Medium",
           "high": "High",
-          "timeBased": "Time based"
+          "time_based": "Time based"
         }
       }
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "webasto-next-modbus"
-version = "1.3.1"
+version = "1.4.0"
 description = "Home Assistant integration for Webasto Next / Ampure Unite wallboxes via Modbus TCP and REST API"
 authors = [{ name = "Webasto Next maintainers" }]
 readme = "README.md"
@@ -108,5 +108,5 @@ DEP004 = ["homeassistant", "voluptuous"]
 
 [tool.codespell]
 skip = "*.pdf,*.log,*.log.*,*.csv"
-ignore-words-list = "hass,alle,unter,adresse,ist,oder,paket,intervall,stopp,startet,aktive,variante"
+ignore-words-list = "hass,alle,unter,adresse,ist,oder,paket,intervall,stopp,startet,aktive,variante,randomised"
 

--- a/tests/test_rest_client_unite.py
+++ b/tests/test_rest_client_unite.py
@@ -166,6 +166,35 @@ async def test_unite_led_brightness_not_supported() -> None:
     client._update_config.assert_not_awaited()
 
 
+async def test_unite_unknown_bool_is_none() -> None:
+    client = _unite_client()
+    client._get = AsyncMock(  # type: ignore[method-assign]
+        return_value=[{"fieldKey": "ocppConfigurations.freeModeActive", "value": "maybe"}]
+    )
+
+    data = await client.get_data()
+
+    assert data.free_charging_enabled is None
+
+
+async def test_next_led_dimming_not_supported() -> None:
+    client = _next_client()
+    client._update_config = AsyncMock()  # type: ignore[method-assign]
+
+    with pytest.raises(RestClientError):
+        await client.set_led_dimming_level("mid")
+    client._update_config.assert_not_awaited()
+
+
+async def test_next_randomised_delay_not_supported() -> None:
+    client = _next_client()
+    client._update_config = AsyncMock()  # type: ignore[method-assign]
+
+    with pytest.raises(RestClientError):
+        await client.set_randomised_delay(60)
+    client._update_config.assert_not_awaited()
+
+
 async def test_next_set_free_charging_uses_boolean_update_type() -> None:
     client = _next_client()
     client._update_config = AsyncMock()  # type: ignore[method-assign]

--- a/tests/test_rest_client_unite.py
+++ b/tests/test_rest_client_unite.py
@@ -1,0 +1,194 @@
+"""Tests for the model-aware REST client (Next vs Unite)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.webasto_next_modbus.const import MODEL_NEXT, MODEL_UNITE
+from custom_components.webasto_next_modbus.rest_client import RestClient, RestClientError
+
+pytestmark = pytest.mark.asyncio
+
+# A trimmed sample of the Unite's GET /api/configuration-fields/ response
+# (scrubbed dump from issue #97).
+UNITE_FIELDS = [
+    {"fieldKey": "wifiSettings.ssid", "value": "irrelevant"},
+    {"fieldKey": "ocppConfigurations.freeModeActive", "value": "FALSE"},
+    {"fieldKey": "ocppConfigurations.freeModeRfid", "value": "TAG-123"},
+    {"fieldKey": "generalSettings.ledDimmingLevel", "value": "mid"},
+    {"fieldKey": "generalSettings.randomisedDelayMaximumDuration", "value": 0},
+]
+
+
+def _unite_client() -> RestClient:
+    client = RestClient("host", "admin", "pw", MagicMock(), model=MODEL_UNITE)
+    client._ensure_token = AsyncMock()  # type: ignore[method-assign]
+    return client
+
+
+def _next_client() -> RestClient:
+    client = RestClient("host", "admin", "pw", MagicMock(), model=MODEL_NEXT)
+    client._ensure_token = AsyncMock()  # type: ignore[method-assign]
+    return client
+
+
+async def test_unite_get_data_parses_configuration_fields() -> None:
+    client = _unite_client()
+    client._get = AsyncMock(return_value=UNITE_FIELDS)  # type: ignore[method-assign]
+
+    data = await client.get_data()
+
+    client._get.assert_awaited_once_with("/configuration-fields/")
+    assert data.free_charging_enabled is False
+    assert data.free_charging_tag_id == "TAG-123"
+    assert data.led_dimming_level == "mid"
+    assert data.randomised_delay == 0
+    # Diagnostic sensors are not available on the Unite.
+    assert data.comboard_sw_version is None
+
+
+async def test_unite_free_charging_true_parses() -> None:
+    client = _unite_client()
+    client._get = AsyncMock(  # type: ignore[method-assign]
+        return_value=[{"fieldKey": "ocppConfigurations.freeModeActive", "value": "TRUE"}]
+    )
+
+    data = await client.get_data()
+
+    assert data.free_charging_enabled is True
+
+
+async def test_unite_unknown_led_level_is_dropped() -> None:
+    client = _unite_client()
+    client._get = AsyncMock(  # type: ignore[method-assign]
+        return_value=[{"fieldKey": "generalSettings.ledDimmingLevel", "value": "bogus"}]
+    )
+
+    data = await client.get_data()
+
+    assert data.led_dimming_level is None
+
+
+async def test_unite_set_free_charging_payload() -> None:
+    client = _unite_client()
+    client._update_config = AsyncMock()  # type: ignore[method-assign]
+
+    await client.set_free_charging(enabled=False)
+
+    client._update_config.assert_awaited_once_with(
+        [
+            {
+                "fieldKey": "ocppConfigurations.freeModeActive",
+                "value": "FALSE",
+                "configurationFieldUpdateType": "simple-configuration-field-update",
+            }
+        ]
+    )
+
+
+async def test_unite_set_free_charging_tag_payload() -> None:
+    client = _unite_client()
+    client._update_config = AsyncMock()  # type: ignore[method-assign]
+
+    await client.set_free_charging_tag_id("NEW-TAG")
+
+    client._update_config.assert_awaited_once_with(
+        [
+            {
+                "fieldKey": "ocppConfigurations.freeModeRfid",
+                "value": "NEW-TAG",
+                "configurationFieldUpdateType": "simple-configuration-field-update",
+            }
+        ]
+    )
+
+
+async def test_unite_set_led_dimming_payload() -> None:
+    client = _unite_client()
+    client._update_config = AsyncMock()  # type: ignore[method-assign]
+
+    await client.set_led_dimming_level("veryLow")
+
+    client._update_config.assert_awaited_once_with(
+        [
+            {
+                "fieldKey": "generalSettings.ledDimmingLevel",
+                "value": "veryLow",
+                "configurationFieldUpdateType": "simple-configuration-field-update",
+            }
+        ]
+    )
+
+
+async def test_unite_set_led_dimming_rejects_unknown_level() -> None:
+    client = _unite_client()
+    client._update_config = AsyncMock()  # type: ignore[method-assign]
+
+    with pytest.raises(ValueError):
+        await client.set_led_dimming_level("bogus")
+    client._update_config.assert_not_awaited()
+
+
+async def test_unite_set_randomised_delay_payload() -> None:
+    client = _unite_client()
+    client._update_config = AsyncMock()  # type: ignore[method-assign]
+
+    await client.set_randomised_delay(600)
+
+    client._update_config.assert_awaited_once_with(
+        [
+            {
+                "fieldKey": "generalSettings.randomisedDelayMaximumDuration",
+                "value": "600",
+                "configurationFieldUpdateType": "simple-configuration-field-update",
+            }
+        ]
+    )
+
+
+async def test_unite_set_randomised_delay_out_of_range() -> None:
+    client = _unite_client()
+    client._update_config = AsyncMock()  # type: ignore[method-assign]
+
+    with pytest.raises(ValueError):
+        await client.set_randomised_delay(3600)
+    client._update_config.assert_not_awaited()
+
+
+async def test_unite_led_brightness_not_supported() -> None:
+    client = _unite_client()
+    client._update_config = AsyncMock()  # type: ignore[method-assign]
+
+    with pytest.raises(RestClientError):
+        await client.set_led_brightness(50)
+    client._update_config.assert_not_awaited()
+
+
+async def test_next_set_free_charging_uses_boolean_update_type() -> None:
+    client = _next_client()
+    client._update_config = AsyncMock()  # type: ignore[method-assign]
+
+    await client.set_free_charging(enabled=True)
+
+    client._update_config.assert_awaited_once_with(
+        [
+            {
+                "fieldKey": "free-charging",
+                "value": True,
+                "configurationFieldUpdateType": "boolean-configuration-field-update",
+            }
+        ]
+    )
+
+
+async def test_next_get_data_uses_sections() -> None:
+    client = _next_client()
+    client._get_section = AsyncMock(return_value=[])  # type: ignore[method-assign]
+    client._get_current_errors = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+    await client.get_data()
+
+    # Next reads the per-section endpoints, not the Unite's flat one.
+    assert client._get_section.await_count == 2


### PR DESCRIPTION
## Summary

Implements REST API support for the **Ampure / Webasto Unite**, tracked in #97. Reverse-engineered and verified on FW 3.187 by @lonkhuijzen (discussion #96, dump + write format in #97).

The REST client was written for the **Next** and did nothing on the Unite, whose REST surface differs: a single flat `GET /api/configuration-fields/` endpoint (the Next's per-section endpoints 404), dotted field keys, and a single write update type `simple-configuration-field-update`. The client is now **model-aware**.

## What a Unite gets (REST enabled)

| Entity | Field | Notes |
| --- | --- | --- |
| Free charging (switch) | `ocppConfigurations.freeModeActive` | `TRUE`/`FALSE` |
| Free charging tag (text) | `ocppConfigurations.freeModeRfid` | |
| **LED dimming level** (select, new) | `generalSettings.ledDimmingLevel` | `veryLow`/`low`/`mid`/`high`/`timeBased` — the Unite has no 0-100 brightness |
| **Randomised start delay** (number, new) | `generalSettings.randomisedDelayMaximumDuration` | 0–1800 s |
| Restart (button) | `custom-actions/restart-system` | already worked |

The free-charging switch and tag were already model-agnostic — they now work on the Unite purely via the model-aware client. The Next's **firmware/diagnostic REST sensors have no Unite equivalent** (that data isn't in the Unite's REST API) and are not created on a Unite; live telemetry is unaffected (Modbus).

## Changes

- **`rest_client.py`**: `model` param; `get_data()` dispatches to a Unite reader (`configuration-fields` → `RestData`); model-aware `set_free_charging` / `set_free_charging_tag_id`; new `set_led_dimming_level` / `set_randomised_delay`; `set_led_brightness` raises a clear error on a Unite. New `RestData` fields `led_dimming_level`, `randomised_delay`.
- **`coordinator.py` / `__init__.py`**: thread the model to the REST client; register the new `select` platform.
- **`number.py`**: LED brightness → Next-only; new `WebastoRandomisedDelay` (Unite).
- **`select.py`** (new): `WebastoLedDimming` (Unite).
- **`const.py`**: `UNITE_LED_DIMMING_LEVELS`, `UNITE_RANDOMISED_DELAY_MAX`.
- **translations (en/de)** incl. select option labels; **icons**; **tests** (`tests/test_rest_client_unite.py`) for the Unite parse + exact write payloads and that the Next path is unchanged.
- Version → **1.4.0**; `randomised` added to the codespell allowlist (matches the vendor field spelling).

## Verified write format (from #97)

```json
POST /api/configuration-updates
[{ "fieldKey": "ocppConfigurations.freeModeActive", "value": "FALSE",
   "configurationFieldUpdateType": "simple-configuration-field-update" }]
→ {"status": "SUCCESS"}
```
Confirmed by @lonkhuijzen for `freeModeActive` and `ledDimmingLevel`; `randomisedDelayMaximumDuration` uses the same shape (to be confirmed on hardware in the beta).

## Test plan

- [ ] CI green (ruff, codespell, mypy strict, hassfest, pytest incl. the new Unite REST tests).
- [ ] After merge: cut **v1.4.0-beta.1** for @lonkhuijzen & other Unite owners to verify on real hardware — we have no Unite to test against, and the randomised-delay write in particular is not yet hardware-confirmed.

Related: #96, #97

_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01554k46k6a5Eiz7Jcvg6FVt)_